### PR TITLE
Issue 76 config bind and port

### DIFF
--- a/cmd/tegola/cmd/root.go
+++ b/cmd/tegola/cmd/root.go
@@ -32,8 +32,8 @@ func init() {
 	// root
 	RootCmd.PersistentFlags().StringVar(&configFile, "config", "config.toml", "path to config file")
 
-	// server
-	serverCmd.Flags().StringVarP(&serverPort, "port", "p", ":8080", "port to bind tile server to")
+	//	server
+	serverCmd.Flags().StringVarP(&bindAddress, "bind", "b", ":8080", "address to bind tile server to")
 	RootCmd.AddCommand(serverCmd)
 
 	// cache seed / purge

--- a/cmd/tegola/cmd/server.go
+++ b/cmd/tegola/cmd/server.go
@@ -2,14 +2,14 @@ package cmd
 
 import (
 	gdcmd "github.com/gdey/cmd"
-	"github.com/spf13/cobra"
 	"github.com/go-spatial/tegola/provider"
 	"github.com/go-spatial/tegola/server"
+	"github.com/spf13/cobra"
 )
 
 var (
-	serverPort      string
-	defaultHTTPPort = ":8080"
+	bindAddress        string
+	defaultBindAddress = ":8080"
 )
 
 var serverCmd = &cobra.Command{
@@ -23,8 +23,8 @@ var serverCmd = &cobra.Command{
 
 		//	check config for server port setting
 		//	if you set the port via the comand line it will override the port setting in the config
-		if serverPort == defaultHTTPPort && conf.Webserver.Port != "" {
-			serverPort = conf.Webserver.Port
+		if bindAddress == defaultBindAddress && conf.Webserver.Bind != "" {
+			bindAddress = conf.Webserver.Bind
 		}
 
 		//	set our server version
@@ -42,10 +42,9 @@ var serverCmd = &cobra.Command{
 		}
 
 		//	start our webserver
-		srv := server.Start(serverPort)
+		server.Start(bindAddress)
 		shutdown(srv)
 		<-gdcmd.Cancelled()
 		gdcmd.Complete()
-
 	},
 }

--- a/cmd/tegola/cmd/server.go
+++ b/cmd/tegola/cmd/server.go
@@ -8,6 +8,11 @@ import (
 )
 
 var (
+	defaultPort     = 8080
+	defaultHostName = ""
+	port            int
+	hostName        string
+
 	bindAddress        string
 	defaultBindAddress = ":8080"
 )
@@ -21,10 +26,14 @@ var serverCmd = &cobra.Command{
 		initConfig()
 		gdcmd.OnComplete(provider.Cleanup)
 
-		//	check config for server port setting
-		//	if you set the port via the comand line it will override the port setting in the config
-		if bindAddress == defaultBindAddress && conf.Webserver.Bind != "" {
-			bindAddress = conf.Webserver.Bind
+		port = defaultPort
+		if conf.Webserver.Port != 0 {
+			port = conf.Webserver.Port
+		}
+
+		hostName = defaultHostName
+		if conf.Webserver.HostName != "" {
+			hostName = conf.Webserver.HostName
 		}
 
 		//	set our server version
@@ -42,7 +51,7 @@ var serverCmd = &cobra.Command{
 		}
 
 		//	start our webserver
-		server.Start(bindAddress)
+		srv := server.Start(hostName, port)
 		shutdown(srv)
 		<-gdcmd.Cancelled()
 		gdcmd.Complete()

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 type Webserver struct {
 	Bind              string `toml:"bind"`
 	HostName          string `toml:"hostname"`
-	Port              string `toml:"port"`
+	Port              int    `toml:"port"`
 	CORSAllowedOrigin string `toml:"cors_allowed_origin"`
 	LogFile           string `toml:"log_file"`
 	LogFormat         string `toml:"log_format"`

--- a/config/config.go
+++ b/config/config.go
@@ -35,9 +35,12 @@ type Config struct {
 }
 
 type Webserver struct {
+	Bind              string `toml:"bind"`
 	HostName          string `toml:"hostname"`
 	Port              string `toml:"port"`
 	CORSAllowedOrigin string `toml:"cors_allowed_origin"`
+	LogFile           string `toml:"log_file"`
+	LogFormat         string `toml:"log_format"`
 }
 
 // A Map represents a map in the Tegola Config file.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -59,8 +59,11 @@ func TestParse(t *testing.T) {
 
 				[webserver]
 				hostname = "cdn.tegola.io"
-				port = ":8080"
+				port = 8080
+				bind = ":8080"
 				cors_allowed_origin = "tegola.io"
+				log_file = "/var/log/tegola/tegola.log"
+				log_format = "{{.Time}}:{{.RequestIP}} —— Tile:{{.Z}}/{{.X}}/{{.Y}}"
 
 				[cache]
 				type = "file"
@@ -97,8 +100,11 @@ func TestParse(t *testing.T) {
 				LocationName: "",
 				Webserver: config.Webserver{
 					HostName:          "cdn.tegola.io",
-					Port:              ":8080",
+					Port:              8080,
+					Bind:              ":8080",
 					CORSAllowedOrigin: "tegola.io",
+					LogFile:           "/var/log/tegola/tegola.log",
+					LogFormat:         "{{.Time}}:{{.RequestIP}} —— Tile:{{.Z}}/{{.X}}/{{.Y}}",
 				},
 				Cache: map[string]interface{}{
 					"type":     "file",
@@ -145,7 +151,10 @@ func TestParse(t *testing.T) {
 			config: `
 				[webserver]
 				hostname = "cdn.tegola.io"
-				port = ":8080"
+				port = 8080
+				bind = ":8080"
+				log_file = "/var/log/tegola/tegola.log"
+				log_format = "{{.Time}}:{{.RequestIP}} —— Tile:{{.Z}}/{{.X}}/{{.Y}}"
 
 				[[providers]]
 				name = "provider1"
@@ -206,8 +215,11 @@ func TestParse(t *testing.T) {
 			expected: config.Config{
 				LocationName: "",
 				Webserver: config.Webserver{
-					HostName: "cdn.tegola.io",
-					Port:     ":8080",
+					HostName:  "cdn.tegola.io",
+					Port:      8080,
+					Bind:      ":8080",
+					LogFile:   "/var/log/tegola/tegola.log",
+					LogFormat: "{{.Time}}:{{.RequestIP}} —— Tile:{{.Z}}/{{.X}}/{{.Y}}",
 				},
 				Providers: []map[string]interface{}{
 					{
@@ -309,7 +321,10 @@ func TestValidate(t *testing.T) {
 			config: config.Config{
 				LocationName: "",
 				Webserver: config.Webserver{
-					Port: ":8080",
+					Port:      8080,
+					Bind:      ":8080",
+					LogFile:   "/var/log/tegola/tegola.log",
+					LogFormat: "{{.Time}}:{{.RequestIP}} —— Tile:{{.Z}}/{{.X}}/{{.Y}}",
 				},
 				Providers: []map[string]interface{}{
 					{
@@ -443,7 +458,10 @@ func TestValidate(t *testing.T) {
 			config: config.Config{
 				LocationName: "",
 				Webserver: config.Webserver{
-					Port: ":8080",
+					Port:      8080,
+					Bind:      ":8080",
+					LogFile:   "/var/log/tegola/tegola.log",
+					LogFormat: "{{.Time}}:{{.RequestIP}} —— Tile:{{.Z}}/{{.X}}/{{.Y}}",
 				},
 				Providers: []map[string]interface{}{
 					{

--- a/server/handle_capabilities_test.go
+++ b/server/handle_capabilities_test.go
@@ -21,7 +21,7 @@ func TestHandleCapabilities(t *testing.T) {
 	testcases := []struct {
 		handler    http.Handler
 		hostname   string
-		port       string
+		port       int
 		uri        string
 		uriPattern string
 		reqMethod  string
@@ -67,12 +67,12 @@ func TestHandleCapabilities(t *testing.T) {
 				},
 			},
 		},
-		// With hostname set and port set to "none" in config, urls should have host "cdn.tegola.io"
+		// With hostname set and port negative in config, urls should have host "cdn.tegola.io"
 		// debug layers turned on
 		{
 			handler:    server.HandleCapabilities{},
 			hostname:   "cdn.tegola.io",
-			port:       "none", // Set to none or port 8080 from uri will be used.
+			port:       -1,
 			uri:        "http://localhost:8080/capabilities?debug=true",
 			uriPattern: "/capabilities",
 			reqMethod:  "GET",
@@ -170,7 +170,6 @@ func TestHandleCapabilities(t *testing.T) {
 		{
 			handler:    server.HandleCapabilities{},
 			hostname:   "cdn.tegola.io",
-			port:       "none", // Set to none or port 8080 from uri will be used.
 			uri:        "http://localhost/capabilities?debug=true",
 			uriPattern: "/capabilities",
 			reqMethod:  "GET",
@@ -324,8 +323,7 @@ func TestHandleCapabilities(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(test.expected, capabilities) {
-			t.Errorf("[%v] response body and expected do not match \n%+v\n%+v", i, test.expected, capabilities)
-			continue
+			t.Errorf("[%v] response body and expected do not match \n%+v\n%+v", i, capabilities, test.expected)
 		}
 	}
 }

--- a/server/handle_map_capabilities_test.go
+++ b/server/handle_map_capabilities_test.go
@@ -21,7 +21,7 @@ func TestHandleMapCapabilities(t *testing.T) {
 	testcases := []struct {
 		handler    http.Handler
 		hostName   string
-		port       string
+		port       int
 		uri        string
 		uriPattern string
 		reqMethod  string
@@ -83,7 +83,7 @@ func TestHandleMapCapabilities(t *testing.T) {
 		{
 			handler:    server.HandleCapabilities{},
 			hostName:   "cdn.tegola.io",
-			port:       "none",
+			port:       -1,
 			uri:        "http://localhost:8080/capabilities/test-map.json?debug=true",
 			uriPattern: "/capabilities/:map_name",
 			reqMethod:  "GET",
@@ -158,6 +158,61 @@ func TestHandleMapCapabilities(t *testing.T) {
 				},
 			},
 		},
+		// Check that port config value is respected in capablity's urls
+		{
+			handler:    server.HandleCapabilities{},
+			hostName:   "",
+			port:       9000,
+			uri:        "http://localhost:8080/capabilities/test-map.json",
+			uriPattern: "/capabilities/:map_name",
+			reqMethod:  "GET",
+			expected: tilejson.TileJSON{
+				Attribution: &testMapAttribution,
+				Bounds:      [4]float64{-180.0, -85.0511, 180.0, 85.0511},
+				Center:      testMapCenter,
+				Format:      "pbf",
+				MinZoom:     4,
+				MaxZoom:     testLayer3.MaxZoom, //	the max zoom for the test group is in layer 3
+				Name:        &testMapName,
+				Description: nil,
+				Scheme:      tilejson.SchemeXYZ,
+				TileJSON:    tilejson.Version,
+				Tiles: []string{
+					"http://localhost:9000/maps/test-map/{z}/{x}/{y}.pbf",
+				},
+				Grids:    []string{},
+				Data:     []string{},
+				Version:  "1.0.0",
+				Template: nil,
+				Legend:   nil,
+				VectorLayers: []tilejson.VectorLayer{
+					{
+						Version:      2,
+						Extent:       4096,
+						ID:           testLayer1.MVTName(),
+						Name:         testLayer1.MVTName(),
+						GeometryType: tilejson.GeomTypePoint,
+						MinZoom:      testLayer1.MinZoom,
+						MaxZoom:      testLayer3.MaxZoom, //	layer 1 and layer 3 share a name in our test so the zoom range includes the entire zoom range
+						Tiles: []string{
+							fmt.Sprintf("http://localhost:9000/maps/test-map/%v/{z}/{x}/{y}.pbf", testLayer1.MVTName()),
+						},
+					},
+					{
+						Version:      2,
+						Extent:       4096,
+						ID:           testLayer2.MVTName(),
+						Name:         testLayer2.MVTName(),
+						GeometryType: tilejson.GeomTypeLine,
+						MinZoom:      testLayer2.MinZoom,
+						MaxZoom:      testLayer2.MaxZoom,
+						Tiles: []string{
+							fmt.Sprintf("http://localhost:9000/maps/test-map/%v/{z}/{x}/{y}.pbf", testLayer2.MVTName()),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, test := range testcases {
@@ -201,8 +256,12 @@ func TestHandleMapCapabilities(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(test.expected, tileJSON) {
-			t.Errorf("[%v] response body and expected do not match \n%+v\n%+v", i, test.expected, tileJSON)
+			t.Errorf("[%v] response body and expected do not match \n%+v\n%+v", i, tileJSON, test.expected)
 			continue
 		}
+
+		// Reset server values to avoid polluting future tests
+		server.HostName = ""
+		server.Port = 0
 	}
 }

--- a/server/server_internal_test.go
+++ b/server/server_internal_test.go
@@ -11,7 +11,7 @@ func TestHostName(t *testing.T) {
 	testcases := []struct {
 		url      string
 		hostName string
-		port     string
+		port     int
 		expected string
 	}{
 		// With no host or port set in config, the hostname should match that used in request uri
@@ -22,11 +22,18 @@ func TestHostName(t *testing.T) {
 		},
 		// With a hostname set in config, that's what the resulting hostname should equal
 		{
-			// With hostname set and port set to "none" in config, expect "cdn.tegola.io"
+			// With hostname set and negative port in config, expect "cdn.tegola.io" despite url port
 			url:      "http://localhost:8080/capabilities",
+			port:     -1,
 			hostName: "cdn.tegola.io",
-			port:     "none",
 			expected: "cdn.tegola.io",
+		},
+		{
+			// With hostname and port set in config, expect <config_host>:<config_port>
+			url:      "http://localhost:8080/capabilities",
+			port:     9000,
+			hostName: "cdn.tegola.io",
+			expected: "cdn.tegola.io:9000",
 		},
 		{
 			// Hostname set, no port in config, but port in url.  Expect <config_host>:<url_port>.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -10,7 +10,6 @@ import (
 
 //	test server config
 const (
-	httpPort       = ":8080"
 	serverVersion  = "0.4.0"
 	serverHostName = "tegola.io"
 )


### PR DESCRIPTION
Rename current (string) 'port' config parameter to 'bind'.
Add int 'port' parameter (used in generating urls).
