### PR TITLE
Issue 228 tile obtained outside proj.

### DIFF
--- a/cmd/tegola/cmd/cache.go
+++ b/cmd/tegola/cmd/cache.go
@@ -240,10 +240,17 @@ var cacheCmd = &cobra.Command{
 		for i := range zooms {
 
 			topLeft := tegola.Tile{Z: zooms[i], Long: bounds[0], Lat: bounds[1]}
-			minx, maxy = topLeft.Deg2Num()
+			var errTL error
+			minx, maxy, errTL = topLeft.Deg2Num()
 
 			bottomRight := tegola.Tile{Z: zooms[i], Long: bounds[2], Lat: bounds[3]}
-			maxx, miny = bottomRight.Deg2Num()
+			var errBR error
+			maxx, miny, errBR = bottomRight.Deg2Num()
+
+			if errTL != nil || errBR != nil {
+				log.Printf("Problem(s) with Deg2Num() at zoom %v, skipping: %v / %v", zooms[i], errTL, errBR)
+				continue
+			}
 
 			//	range rows
 			for x := minx; x <= maxx; x++ {

--- a/cmd/tegola/cmd/cache.go
+++ b/cmd/tegola/cmd/cache.go
@@ -238,17 +238,20 @@ var cacheCmd = &cobra.Command{
 
 		//	iterate our zoom range
 		for i := range zooms {
+			var err error
 
 			topLeft := tegola.Tile{Z: zooms[i], Long: bounds[0], Lat: bounds[1]}
-			var errTL error
-			minx, maxy, errTL = topLeft.Deg2Num()
+			minx, maxy, err = topLeft.Deg2Num()
+			if err != nil {
+				log.Printf("error calculating Z/X/Y tile from zoom (%v), and lat / long (%v, %v) skipping: %v", zooms[i], topLeft.Lat, topLeft.Long, err)
+				continue
+			}
 
 			bottomRight := tegola.Tile{Z: zooms[i], Long: bounds[2], Lat: bounds[3]}
-			var errBR error
-			maxx, miny, errBR = bottomRight.Deg2Num()
 
-			if errTL != nil || errBR != nil {
-				log.Printf("Problem(s) with Deg2Num() at zoom %v, skipping: %v / %v", zooms[i], errTL, errBR)
+			maxx, miny, err = bottomRight.Deg2Num()
+			if err != nil {
+				log.Printf("error calculating Z/X/Y tile from zoom (%v), and lat / long (%v, %v) skipping: %v", zooms[i], bottomRight.Lat, bottomRight.Long, err)
 				continue
 			}
 

--- a/tile.go
+++ b/tile.go
@@ -31,7 +31,7 @@ func (t *Tile) Deg2Num() (x, y int, err error) {
 		msg := fmt.Sprintf("One or both outside valid range (Long, Lat): (%v, %v)", t.Long, t.Lat)
 		err = fmt.Errorf("%v", msg)
 		log.Print(err)
-		return 0, 0, err
+		return -1, -1, err
 	}
 
 	x = int(math.Floor((t.Long + 180.0) / 360.0 * (math.Exp2(float64(t.Z)))))
@@ -40,7 +40,7 @@ func (t *Tile) Deg2Num() (x, y int, err error) {
 	return
 }
 
-func (t *Tile) Num2Deg() (lat, lng float64) {
+func (t *Tile) Num2Deg() (lat, lng float64, err error) {
 	//	WGS84Bounds       = [4]float64{-180.0, -85.0511, 180.0, 85.0511}
 	//	WebMercatorBounds = [4]float64{-20026376.39, -20048966.10, 20026376.39, 20048966.10}
 	n := math.Pi - 2.0*math.Pi*float64(t.Y)/math.Exp2(float64(t.Z))
@@ -48,7 +48,14 @@ func (t *Tile) Num2Deg() (lat, lng float64) {
 	lat = 180.0 / math.Pi * math.Atan(0.5*(math.Exp(n)-math.Exp(-n)))
 	lng = float64(t.X)/math.Exp2(float64(t.Z))*360.0 - 180.0
 
-	return lat, lng
+	if lat < -85.0511 || lat > 85.0511 || lng < -180.0 || lng > 180.0 {
+		msg := fmt.Sprintf("One or both outside valid range (x, y): (%v, %v)", t.X, t.Y)
+		err = fmt.Errorf("%v", msg)
+		log.Print(err)
+		return -400.0, -400.0, err
+	}
+
+	return lat, lng, nil
 }
 
 //BoundingBox returns the bound box coordinates for upper left (ulx, uly) and lower right (lrx, lry)

--- a/tile.go
+++ b/tile.go
@@ -28,8 +28,7 @@ func (t *Tile) Deg2Num() (x, y int, err error) {
 
 	// Check that input lat/long values are within WGS84 bounds
 	if t.Lat < -85.0511 || t.Lat > 85.0511 || t.Long < -180.0 || t.Long > 180.0 {
-		msg := fmt.Sprintf("One or both outside valid range (Long, Lat): (%v, %v)", t.Long, t.Lat)
-		err = fmt.Errorf("%v", msg)
+		err := fmt.Errorf("one or both outside valid range (Long, Lat): (%v, %v)", t.Long, t.Lat)
 		log.Print(err)
 		return -1, -1, err
 	}
@@ -49,8 +48,7 @@ func (t *Tile) Num2Deg() (lat, lng float64, err error) {
 	lng = float64(t.X)/math.Exp2(float64(t.Z))*360.0 - 180.0
 
 	if lat < -85.0511 || lat > 85.0511 || lng < -180.0 || lng > 180.0 {
-		msg := fmt.Sprintf("One or both outside valid range (x, y): (%v, %v)", t.X, t.Y)
-		err = fmt.Errorf("%v", msg)
+		err := fmt.Errorf("one or both outside valid range (x, y): (%v, %v)", t.X, t.Y)
 		log.Print(err)
 		return -400.0, -400.0, err
 	}

--- a/tile_test.go
+++ b/tile_test.go
@@ -30,7 +30,7 @@ func TestTileNum2Deg(t *testing.T) {
 			},
 			expectedLat: -400.0,
 			expectedLng: -400.0,
-			expectedErr: "One or both outside valid range (x, y): (-1, 1)",
+			expectedErr: "one or both outside valid range (x, y): (-1, 1)",
 		},
 		{ // Confirm that negative row (y) value results in an error
 			tile: tegola.Tile{
@@ -40,7 +40,7 @@ func TestTileNum2Deg(t *testing.T) {
 			},
 			expectedLat: -400.0,
 			expectedLng: -400.0,
-			expectedErr: "One or both outside valid range (x, y): (1, -1)",
+			expectedErr: "one or both outside valid range (x, y): (1, -1)",
 		},
 	}
 
@@ -86,7 +86,7 @@ func TestTileDeg2Num(t *testing.T) {
 			},
 			expectedX:   -1,
 			expectedY:   -1,
-			expectedErr: "One or both outside valid range (Long, Lat): (-180, -85.1)",
+			expectedErr: "one or both outside valid range (Long, Lat): (-180, -85.1)",
 		},
 		{ // Check for error if Long outside WGS84 Range
 			tile: tegola.Tile{
@@ -96,7 +96,7 @@ func TestTileDeg2Num(t *testing.T) {
 			},
 			expectedX:   -1,
 			expectedY:   -1,
-			expectedErr: "One or both outside valid range (Long, Lat): (-180.1, -85)",
+			expectedErr: "one or both outside valid range (Long, Lat): (-180.1, -85)",
 		},
 	}
 

--- a/tile_test.go
+++ b/tile_test.go
@@ -11,6 +11,7 @@ func TestTileNum2Deg(t *testing.T) {
 		tile        tegola.Tile
 		expectedLat float64
 		expectedLng float64
+		expectedErr string
 	}{
 		{
 			tile: tegola.Tile{
@@ -21,10 +22,37 @@ func TestTileNum2Deg(t *testing.T) {
 			expectedLat: 66.51326044311185,
 			expectedLng: -90,
 		},
+		{ // Confirm that negative column (x) value results in an error
+			tile: tegola.Tile{
+				Z: 2,
+				X: -1,
+				Y: 1,
+			},
+			expectedLat: -400.0,
+			expectedLng: -400.0,
+			expectedErr: "One or both outside valid range (x, y): (-1, 1)",
+		},
+		{ // Confirm that negative row (y) value results in an error
+			tile: tegola.Tile{
+				Z: 2,
+				X: 1,
+				Y: -1,
+			},
+			expectedLat: -400.0,
+			expectedLng: -400.0,
+			expectedErr: "One or both outside valid range (x, y): (1, -1)",
+		},
 	}
 
 	for i, test := range testcases {
-		lat, lng := test.tile.Num2Deg()
+		lat, lng, err := test.tile.Num2Deg()
+
+		if test.expectedErr != "" {
+			if err.Error() != test.expectedErr {
+				t.Errorf("Failed test %v. Expected err (%v), got (%v)", i, test.expectedErr, err.Error())
+			}
+		}
+
 		if lat != test.expectedLat {
 			t.Errorf("Failed test %v. Expected lat (%v), got (%v)", i, test.expectedLat, lat)
 		}
@@ -56,8 +84,8 @@ func TestTileDeg2Num(t *testing.T) {
 				Lat:  -85.1,
 				Long: -180,
 			},
-			expectedX:   0,
-			expectedY:   0,
+			expectedX:   -1,
+			expectedY:   -1,
 			expectedErr: "One or both outside valid range (Long, Lat): (-180, -85.1)",
 		},
 		{ // Check for error if Long outside WGS84 Range
@@ -66,8 +94,8 @@ func TestTileDeg2Num(t *testing.T) {
 				Lat:  -85,
 				Long: -180.1,
 			},
-			expectedX:   0,
-			expectedY:   0,
+			expectedX:   -1,
+			expectedY:   -1,
 			expectedErr: "One or both outside valid range (Long, Lat): (-180.1, -85)",
 		},
 	}

--- a/tile_test.go
+++ b/tile_test.go
@@ -11,7 +11,7 @@ func TestTileNum2Deg(t *testing.T) {
 		tile        tegola.Tile
 		expectedLat float64
 		expectedLng float64
-		expectedErr string
+		expectedErr error
 	}{
 		{
 			tile: tegola.Tile{
@@ -28,9 +28,12 @@ func TestTileNum2Deg(t *testing.T) {
 				X: -1,
 				Y: 1,
 			},
-			expectedLat: -400.0,
-			expectedLng: -400.0,
-			expectedErr: "one or both outside valid range (x, y): (-1, 1)",
+			expectedLat: 0.0,
+			expectedLng: 0.0,
+			expectedErr: tegola.ErrInvalidXY{
+				X: -1,
+				Y: 1,
+			},
 		},
 		{ // Confirm that negative row (y) value results in an error
 			tile: tegola.Tile{
@@ -38,26 +41,32 @@ func TestTileNum2Deg(t *testing.T) {
 				X: 1,
 				Y: -1,
 			},
-			expectedLat: -400.0,
-			expectedLng: -400.0,
-			expectedErr: "one or both outside valid range (x, y): (1, -1)",
+			expectedLat: 0.0,
+			expectedLng: 0.0,
+			expectedErr: tegola.ErrInvalidXY{
+				X: 1,
+				Y: -1,
+			},
 		},
 	}
 
 	for i, test := range testcases {
 		lat, lng, err := test.tile.Num2Deg()
 
-		if test.expectedErr != "" {
-			if err.Error() != test.expectedErr {
-				t.Errorf("Failed test %v. Expected err (%v), got (%v)", i, test.expectedErr, err.Error())
+		if test.expectedErr != nil {
+			if err != test.expectedErr {
+				t.Errorf("[%v]. Expected err (%v), got (%v)", i, test.expectedErr, err.Error())
+				continue
 			}
 		}
 
 		if lat != test.expectedLat {
-			t.Errorf("Failed test %v. Expected lat (%v), got (%v)", i, test.expectedLat, lat)
+			t.Errorf("[%v]. Expected lat (%v), got (%v)", i, test.expectedLat, lat)
+			continue
 		}
 		if lng != test.expectedLng {
-			t.Errorf("Failed test %v. Expected lng (%v), got (%v)", i, test.expectedLng, lng)
+			t.Errorf("[%v]. Expected lng (%v), got (%v)", i, test.expectedLng, lng)
+			continue
 		}
 	}
 }
@@ -67,7 +76,7 @@ func TestTileDeg2Num(t *testing.T) {
 		tile        tegola.Tile
 		expectedX   int
 		expectedY   int
-		expectedErr string
+		expectedErr error
 	}{
 		{
 			tile: tegola.Tile{
@@ -84,9 +93,12 @@ func TestTileDeg2Num(t *testing.T) {
 				Lat:  -85.1,
 				Long: -180,
 			},
-			expectedX:   -1,
-			expectedY:   -1,
-			expectedErr: "one or both outside valid range (Long, Lat): (-180, -85.1)",
+			expectedX: 0,
+			expectedY: 0,
+			expectedErr: tegola.ErrInvalidLatLong{
+				Lat:  -85.1,
+				Long: -180,
+			},
 		},
 		{ // Check for error if Long outside WGS84 Range
 			tile: tegola.Tile{
@@ -94,29 +106,37 @@ func TestTileDeg2Num(t *testing.T) {
 				Lat:  -85,
 				Long: -180.1,
 			},
-			expectedX:   -1,
-			expectedY:   -1,
-			expectedErr: "one or both outside valid range (Long, Lat): (-180.1, -85)",
+			expectedX: 0,
+			expectedY: 0,
+			expectedErr: tegola.ErrInvalidLatLong{
+				Lat:  -85,
+				Long: -180.1,
+			},
 		},
 	}
 
 	for i, tc := range testcases {
 		x, y, err := tc.tile.Deg2Num()
 
-		if tc.expectedErr != "" {
+		if tc.expectedErr != nil {
 			if err == nil {
-				t.Errorf("testcase (%v) failed. Got nil error", i)
-			} else if err.Error() != tc.expectedErr {
-				t.Errorf("testcase (%v) failed. expected err (%v) does not match output (%v)", i, tc.expectedErr, err)
+				t.Errorf("[%v]. got nil error but expected err: %v", i, tc.expectedErr)
+				continue
+			}
+			if err != tc.expectedErr {
+				t.Errorf("[%v]. expected err (%v) does not match output (%v)", i, tc.expectedErr, err)
+				continue
 			}
 		}
 
 		if tc.expectedX != x {
-			t.Errorf("testcase (%v) failed. expected X value (%v) does not match output (%v)", i, tc.expectedX, x)
+			t.Errorf("[%v]. expected X value (%v) does not match output (%v)", i, tc.expectedX, x)
+			continue
 		}
 
 		if tc.expectedY != y {
-			t.Errorf("testcase (%v) failed. expected X value (%v) does not match output (%v)", i, tc.expectedY, y)
+			t.Errorf("[%v]. expected Y value (%v) does not match output (%v)", i, tc.expectedY, y)
+			continue
 		}
 	}
 }

--- a/tile_test.go
+++ b/tile_test.go
@@ -36,9 +36,10 @@ func TestTileNum2Deg(t *testing.T) {
 
 func TestTileDeg2Num(t *testing.T) {
 	testcases := []struct {
-		tile      tegola.Tile
-		expectedX int
-		expectedY int
+		tile        tegola.Tile
+		expectedX   int
+		expectedY   int
+		expectedErr string
 	}{
 		{
 			tile: tegola.Tile{
@@ -49,10 +50,38 @@ func TestTileDeg2Num(t *testing.T) {
 			expectedX: 0,
 			expectedY: 0,
 		},
+		{ // Check for error if Lat outside WGS84 Range
+			tile: tegola.Tile{
+				Z:    0,
+				Lat:  -85.1,
+				Long: -180,
+			},
+			expectedX:   0,
+			expectedY:   0,
+			expectedErr: "One or both outside valid range (Long, Lat): (-180, -85.1)",
+		},
+		{ // Check for error if Long outside WGS84 Range
+			tile: tegola.Tile{
+				Z:    0,
+				Lat:  -85,
+				Long: -180.1,
+			},
+			expectedX:   0,
+			expectedY:   0,
+			expectedErr: "One or both outside valid range (Long, Lat): (-180.1, -85)",
+		},
 	}
 
 	for i, tc := range testcases {
-		x, y := tc.tile.Deg2Num()
+		x, y, err := tc.tile.Deg2Num()
+
+		if tc.expectedErr != "" {
+			if err == nil {
+				t.Errorf("testcase (%v) failed. Got nil error", i)
+			} else if err.Error() != tc.expectedErr {
+				t.Errorf("testcase (%v) failed. expected err (%v) does not match output (%v)", i, tc.expectedErr, err)
+			}
+		}
 
 		if tc.expectedX != x {
 			t.Errorf("testcase (%v) failed. expected X value (%v) does not match output (%v)", i, tc.expectedX, x)


### PR DESCRIPTION
Resolves #228 
Updates Deg2Num() & Num2Deg to return (x, y, err) and check if values are within bounds for projection.  This prevents a tegola.Tile with invalid bounds from being propagated beyond these calls.
