### PR TITLE
Issue 189 Tile BBox coordinate order

### DIFF
--- a/basic/g.go
+++ b/basic/g.go
@@ -15,7 +15,6 @@ func (g G) getbase() G {
 		bg, ok = g.Geometry.(G)
 	}
 	return rg
-
 }
 
 func (g G) IsLine() bool {
@@ -45,6 +44,12 @@ func (g G) AsPolygon() Polygon {
 	}
 	return p
 }
+
+func (g G) IsMultiPolygon() bool {
+	_, ok := g.getbase().Geometry.(MultiPolygon)
+	return ok
+}
+
 func (g G) AsMultiPolygon() MultiPolygon {
 	bg := g.getbase()
 	p, ok := bg.Geometry.(MultiPolygon)
@@ -55,7 +60,13 @@ func (g G) AsMultiPolygon() MultiPolygon {
 }
 
 func (g G) IsPoint() bool {
-	_, ok := g.getbase().Geometry.(Point)
+	// While a Point3 can be cast to a Point, we don't want a false positive
+	_, ok := g.getbase().Geometry.(Point3)
+	if ok {
+		return false
+	}
+
+	_, ok = g.getbase().Geometry.(Point)
 	return ok
 }
 
@@ -66,4 +77,61 @@ func (g G) AsPoint() Point {
 		panic(fmt.Sprintf("Geo is not a Point! : %T", bg.Geometry))
 	}
 	return p
+}
+
+func (g G) IsPoint3() bool {
+	_, ok := g.getbase().Geometry.(Point3)
+	return ok
+}
+
+func (g G) AsPoint3() Point3 {
+	p, ok := g.getbase().Geometry.(Point3)
+	if !ok {
+		panic(fmt.Sprintf("Geo is not a Point3! : %T", g.getbase().Geometry))
+	}
+	return p
+}
+
+func (g G) IsMultiPoint() bool {
+	// While a MultiPoint3 can be cast to a MultiPoint, we don't want a false positive
+	_, ok := g.getbase().Geometry.(MultiPoint3)
+	if ok {
+		return false
+	}
+	_, ok = g.getbase().Geometry.(MultiPoint)
+	return ok
+}
+
+func (g G) AsMultiPoint() MultiPoint {
+	mp, ok := g.getbase().Geometry.(MultiPoint)
+	if !ok {
+		panic(fmt.Sprintf("Geo is not a MultiPoint! : %T", g.getbase().Geometry))
+	}
+	return mp
+}
+
+func (g G) IsMultiPoint3() bool {
+	_, ok := g.getbase().Geometry.(MultiPoint3)
+	return ok
+}
+
+func (g G) AsMultiPoint3() MultiPoint3 {
+	mp, ok := g.getbase().Geometry.(MultiPoint3)
+	if !ok {
+		panic(fmt.Sprintf("Geo is not a MultiPoint3! : %T", g.getbase().Geometry))
+	}
+	return mp
+}
+
+func (g G) IsMultiLine() bool {
+	_, ok := g.getbase().Geometry.(MultiLine)
+	return ok
+}
+
+func (g G) AsMultiLine() MultiLine {
+	ml, ok := g.getbase().Geometry.(MultiLine)
+	if !ok {
+		panic(fmt.Sprintf("Geo is not a MultiLine! : %T", g.getbase().Geometry))
+	}
+	return ml
 }

--- a/basic/geometry_math.go
+++ b/basic/geometry_math.go
@@ -153,7 +153,7 @@ func CloneGeometry(geometry tegola.Geometry) (G, error) {
 func ToWebMercator(SRID int, geometry tegola.Geometry) (G, error) {
 	switch SRID {
 	default:
-		return G{}, fmt.Errorf("Don't know how to convert from %v to %v.", tegola.WebMercator, SRID)
+		return G{}, fmt.Errorf("don't know how to convert from %v to %v.", SRID, tegola.WebMercator)
 	case tegola.WebMercator:
 		// Instead of just returning the geometry, we are cloning it so that the user of the API can rely
 		// on the result to alway be a copy. Instead of being a reference in the on instance that it's already
@@ -170,7 +170,7 @@ func ToWebMercator(SRID int, geometry tegola.Geometry) (G, error) {
 func FromWebMercator(SRID int, geometry tegola.Geometry) (G, error) {
 	switch SRID {
 	default:
-		return G{}, fmt.Errorf("Don't know how to convert from %v to %v.", SRID, tegola.WebMercator)
+		return G{}, fmt.Errorf("don't know how to convert from %v to %v.", tegola.WebMercator, SRID)
 	case tegola.WebMercator:
 		// Instead of just returning the geometry, we are cloning it so that the user of the API can rely
 		// on the result to alway be a copy. Instead of being a reference in the on instance that it's already

--- a/basic/geometry_math.go
+++ b/basic/geometry_math.go
@@ -15,15 +15,7 @@ func ApplyToPoints(geometry tegola.Geometry, f func(coords ...float64) ([]float6
 	switch geo := geometry.(type) {
 	default:
 		return G{}, fmt.Errorf("Unknown Geometry: %+v", geometry)
-	case tegola.Point:
-		c, err := f(geo.X(), geo.Y())
-		if err != nil {
-			return G{}, err
-		}
-		if len(c) < 2 {
-			return G{}, fmt.Errorf("Function did not return minimum number of coordinates got %v expected 2", len(c))
-		}
-		return G{Point{c[0], c[1]}}, nil
+	// Any tegola.Point3 is also a valid tegola.Point, make sure the check for Point3 comes before Point.
 	case tegola.Point3:
 		c, err := f(geo.X(), geo.Y(), geo.Z())
 		if err != nil {
@@ -33,6 +25,29 @@ func ApplyToPoints(geometry tegola.Geometry, f func(coords ...float64) ([]float6
 			return G{}, fmt.Errorf("Function did not return minimum number of coordinates got %v expected 3", len(c))
 		}
 		return G{Point3{c[0], c[1], c[2]}}, nil
+	case tegola.Point:
+		c, err := f(geo.X(), geo.Y())
+		if err != nil {
+			return G{}, err
+		}
+		if len(c) < 2 {
+			return G{}, fmt.Errorf("Function did not return minimum number of coordinates got %v expected 2", len(c))
+		}
+		return G{Point{c[0], c[1]}}, nil
+	// Any tegola.MultiPoint3 is also a valid tegola.MultiPoint, make sure the check for MultiPoint3 comes before MultiPoint.
+	case tegola.MultiPoint3:
+		var pts MultiPoint3
+		for _, pt := range geo.Points() {
+			c, err := f(pt.X(), pt.Y(), pt.Z())
+			if err != nil {
+				return G{}, err
+			}
+			if len(c) < 3 {
+				return G{}, fmt.Errorf("Function did not return minimum number of coordinates got %v expected 3", len(c))
+			}
+			pts = append(pts, Point3{c[0], c[1], c[2]})
+		}
+		return G{pts}, nil
 	case tegola.MultiPoint:
 		var pts MultiPoint
 		for _, pt := range geo.Points() {

--- a/basic/geometry_math_test.go
+++ b/basic/geometry_math_test.go
@@ -1,0 +1,122 @@
+package basic_test
+
+import (
+	"testing"
+
+	"github.com/terranodo/tegola"
+	"github.com/terranodo/tegola/basic"
+	"github.com/terranodo/tegola/wkb"
+)
+
+func TestToWebMercator(t *testing.T) {
+	var floatDelta float64 = 0.00001 // floating point comparison fuzziness amount
+
+	type TestCase struct {
+		fromSrid  int // Currently only WGS84 -> WebMercator is supported
+		wgs84G    basic.Geometry
+		expectedG basic.Geometry
+	}
+
+	testCases := []TestCase{
+		{
+			fromSrid: tegola.WGS84,
+			wgs84G: basic.Line{
+				basic.Point{-80.0, -40.0},
+				basic.Point{-40.0, -40.0},
+				basic.Point{-40.0, 0.0},
+				basic.Point{-80.0, 0.0},
+				basic.Point{-80.0, -40.0},
+			},
+			// What it should be after conversion, according to https://mygeodata.cloud/cs2cs/
+			expectedG: basic.Line{
+				basic.Point{-8905559.26346, -4865942.2795},
+				basic.Point{-4452779.63173, -4865942.2795},
+				basic.Point{-4452779.63173, -7.08115455161e-10},
+				basic.Point{-8905559.26346, -7.08115455161e-10},
+				basic.Point{-8905559.26346, -4865942.2795},
+			},
+		},
+		{
+			fromSrid: tegola.WGS84,
+			wgs84G: basic.Polygon{
+				basic.Line{
+					basic.Point{-80.0, -40.0},
+					basic.Point{-40.0, -40.0},
+					basic.Point{-40.0, 0.0},
+					basic.Point{-80.0, 0.0},
+					basic.Point{-80.0, -40.0},
+				},
+			},
+			// What it should be after conversion, according to https://mygeodata.cloud/cs2cs/
+			expectedG: basic.Polygon{
+				basic.Line{
+					basic.Point{-8905559.26346, -4865942.2795},
+					basic.Point{-4452779.63173, -4865942.2795},
+					basic.Point{-4452779.63173, -7.08115455161e-10},
+					basic.Point{-8905559.26346, -7.08115455161e-10},
+					basic.Point{-8905559.26346, -4865942.2795},
+				},
+			},
+		},
+		{
+			fromSrid: tegola.WGS84,
+			wgs84G: basic.Polygon{
+				basic.Line{
+					basic.Point{75.0, -40.0},
+					basic.Point{70.0, 10.0},
+					basic.Point{75.0, 30.0},
+					basic.Point{40.0, 35.0},
+					basic.Point{-10.0, 10.0},
+					basic.Point{-5.3, -25.7},
+					basic.Point{75, -40.0},
+				},
+			},
+			// What it should be after conversion, according to https://mygeodata.cloud/cs2cs/
+			expectedG: basic.Polygon{
+				basic.Line{
+					basic.Point{8348961.8095, -4865942.2795},
+					basic.Point{7792364.35553, 1118889.97486},
+					basic.Point{8348961.8095, 3503549.8435},
+					basic.Point{4452779.63173, 4163881.14406},
+					basic.Point{-1113194.90793, 1118889.97486},
+					basic.Point{-589993.301204, -2961971.85332},
+					basic.Point{8348961.8095, -4865942.2795},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		resultG, err := basic.ToWebMercator(tc.fromSrid, tc.wgs84G)
+		if err != nil {
+			t.Errorf("[%v] Problem in basic.ToWebMercator(): %v\n", i, err)
+			continue
+		}
+
+		switch {
+		case resultG.IsLine():
+			resultLine := resultG.AsLine()
+			expectedLine := tc.expectedG.(basic.Line)
+
+			for j, p := range resultLine {
+				if !basic.PointsEqual(p, expectedLine[j], floatDelta) {
+					t.Errorf("[%v] (Line [%v])\n  %v\n --- != ---\n  %v\n", i, j, p, expectedLine[j])
+				}
+			}
+		case resultG.IsPolygon():
+			resultPolygon := resultG.AsPolygon()
+			expectedPoly := tc.expectedG.(basic.Polygon)
+
+			for j, l := range resultPolygon {
+				expectedLine := expectedPoly.Sublines()[j].(basic.Line)
+				if !basic.LinesEqual(l, expectedLine, floatDelta) {
+					t.Errorf("[%v] (Polygon [%v])\n  %v\n --- != ---\n  %v\n", i, j, wkb.WKT(l), wkb.WKT(expectedLine))
+				}
+			}
+		}
+	}
+}
+
+//ToWebMercator(SRID int, geometry tegola.Geometry) (G, error)
+
+//func FromWebMercator(SRID int, geometry tegola.Geometry) (G, error)

--- a/basic/geometry_math_test.go
+++ b/basic/geometry_math_test.go
@@ -1,6 +1,7 @@
 package basic_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/terranodo/tegola"
@@ -10,14 +11,23 @@ import (
 
 func TestToWebMercator(t *testing.T) {
 	var floatDelta float64 = 0.00001 // floating point comparison fuzziness amount
+	unsupportedSrid := 3157
 
 	type TestCase struct {
-		fromSrid  int // Currently only WGS84 -> WebMercator is supported
-		wgs84G    basic.Geometry
-		expectedG basic.Geometry
+		fromSrid    int // Currently only WGS84 -> WebMercator is supported
+		wgs84G      basic.Geometry
+		expectedG   basic.Geometry
+		expectedErr string
 	}
 
 	testCases := []TestCase{
+		{
+			fromSrid:  unsupportedSrid,
+			wgs84G:    basic.Point{-80.0, -40.0},
+			expectedG: basic.G{},
+			expectedErr: fmt.Sprintf("don't know how to convert from %v to %v.",
+				unsupportedSrid, tegola.WebMercator),
+		},
 		{
 			fromSrid: tegola.WGS84,
 			wgs84G: basic.Line{
@@ -89,8 +99,12 @@ func TestToWebMercator(t *testing.T) {
 	for i, tc := range testCases {
 		resultG, err := basic.ToWebMercator(tc.fromSrid, tc.wgs84G)
 		if err != nil {
-			t.Errorf("[%v] Problem in basic.ToWebMercator(): %v\n", i, err)
-			continue
+			if tc.expectedErr == "" {
+				t.Errorf("[%v] Problem in basic.ToWebMercator(): %v\n", i, err)
+				continue
+			} else if tc.expectedErr != err.Error() {
+				t.Errorf("[%v] expected error not returned: '%v' != '%v'", i, err.Error(), tc.expectedErr)
+			}
 		}
 
 		switch {
@@ -117,6 +131,125 @@ func TestToWebMercator(t *testing.T) {
 	}
 }
 
-//ToWebMercator(SRID int, geometry tegola.Geometry) (G, error)
+func TestFromWebMercator(t *testing.T) {
+	var floatDelta float64 = 0.00001 // floating point comparison fuzziness amount
+	unsupportedSrid := 3157
+	type TestCase struct {
+		toSrid      int // Currently only WebMercator -> WGS84 is supported
+		webMerc     basic.Geometry
+		expectedG   basic.Geometry
+		expectedErr string
+	}
 
-//func FromWebMercator(SRID int, geometry tegola.Geometry) (G, error)
+	testCases := []TestCase{
+		{
+			toSrid:    unsupportedSrid,
+			webMerc:   basic.Point{-8905559.26346, -4865942.2795},
+			expectedG: basic.G{},
+			expectedErr: fmt.Sprintf("don't know how to convert from %v to %v.",
+				tegola.WebMercator, unsupportedSrid),
+		},
+		{
+			toSrid: tegola.WGS84,
+			webMerc: basic.Line{
+				basic.Point{-8905559.26346, -4865942.2795},
+				basic.Point{-4452779.63173, -4865942.2795},
+				basic.Point{-4452779.63173, -7.08115455161e-10},
+				basic.Point{-8905559.26346, -7.08115455161e-10},
+				basic.Point{-8905559.26346, -4865942.2795},
+			},
+			// What it should be after conversion, according to https://mygeodata.cloud/cs2cs/
+			expectedG: basic.Line{
+				basic.Point{-80.0, -40.0},
+				basic.Point{-40.0, -40.0},
+				basic.Point{-40.0, 0.0},
+				basic.Point{-80.0, 0.0},
+				basic.Point{-80.0, -40.0},
+			},
+		},
+		{
+			toSrid: tegola.WGS84,
+			webMerc: basic.Polygon{
+				basic.Line{
+					basic.Point{-8905559.26346, -4865942.2795},
+					basic.Point{-4452779.63173, -4865942.2795},
+					basic.Point{-4452779.63173, -7.08115455161e-10},
+					basic.Point{-8905559.26346, -7.08115455161e-10},
+					basic.Point{-8905559.26346, -4865942.2795},
+				},
+			},
+			// What it should be after conversion, according to https://mygeodata.cloud/cs2cs/
+			expectedG: basic.Polygon{
+				basic.Line{
+					basic.Point{-80.0, -40.0},
+					basic.Point{-40.0, -40.0},
+					basic.Point{-40.0, 0.0},
+					basic.Point{-80.0, 0.0},
+					basic.Point{-80.0, -40.0},
+				},
+			},
+		},
+		{
+			toSrid: tegola.WGS84,
+			webMerc: basic.Polygon{
+				basic.Line{
+					basic.Point{8348961.8095, -4865942.2795},
+					basic.Point{7792364.35553, 1118889.97486},
+					basic.Point{8348961.8095, 3503549.8435},
+					basic.Point{4452779.63173, 4163881.14406},
+					basic.Point{-1113194.90793, 1118889.97486},
+					basic.Point{-589993.301204, -2961971.85332},
+					basic.Point{8348961.8095, -4865942.2795},
+				},
+			},
+			// What it should be after conversion, according to https://mygeodata.cloud/cs2cs/
+			expectedG: basic.Polygon{
+				basic.Line{
+					basic.Point{75.0, -40.0},
+					basic.Point{70.0, 10.0},
+					basic.Point{75.0, 30.0},
+					basic.Point{40.0, 35.0},
+					basic.Point{-10.0, 10.0},
+					basic.Point{-5.3, -25.7},
+					basic.Point{75, -40.0},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		resultG, err := basic.FromWebMercator(tc.toSrid, tc.webMerc)
+		if err != nil {
+			if tc.expectedErr == "" {
+				t.Errorf("[%v] Problem in basic.FromWebMercator(): %v\n", i, err)
+				continue
+			} else {
+				if tc.expectedErr != err.Error() {
+					t.Errorf("[%v] Expected error not returned: '%v' != '%v'", i, err, tc.expectedErr)
+				}
+			}
+		}
+
+		switch {
+		case resultG.IsLine():
+			resultLine := resultG.AsLine()
+			expectedLine := tc.expectedG.(basic.Line)
+
+			for j, p := range resultLine {
+				if !basic.PointsEqual(p, expectedLine[j], floatDelta) {
+					t.Errorf("[%v] (Line [%v])\n  %v\n --- != ---\n  %v\n", i, j, p, expectedLine[j])
+				}
+			}
+		case resultG.IsPolygon():
+			resultPolygon := resultG.AsPolygon()
+			expectedPoly := tc.expectedG.(basic.Polygon)
+
+			for j, l := range resultPolygon {
+				expectedLine := expectedPoly.Sublines()[j].(basic.Line)
+				if !basic.LinesEqual(l, expectedLine, floatDelta) {
+					t.Errorf("[%v] (Polygon [%v])\n  %v\n --- != ---\n  %v\n", i, j, wkb.WKT(l), wkb.WKT(expectedLine))
+				}
+			}
+		}
+	}
+}

--- a/basic/geometry_math_test.go
+++ b/basic/geometry_math_test.go
@@ -253,3 +253,138 @@ func TestFromWebMercator(t *testing.T) {
 		}
 	}
 }
+
+// Testing function passed to basic.ApplyToPoints.  Simply increments each coordinate value.
+func inc(coords ...float64) ([]float64, error) {
+	result := make([]float64, len(coords))
+	for i, c := range coords {
+		result[i] = c + 1.0
+	}
+	return result, nil
+}
+
+func TestApplyToPoints(t *testing.T) {
+	// Acceptable floating point comparison fuzziness amount
+	floatDelta := 0.000001
+
+	type TestCase struct {
+		geom         basic.Geometry
+		expectedGeom basic.Geometry
+	}
+
+	testCases := []TestCase{
+		{
+			geom:         basic.Point{10.3, 11.7},
+			expectedGeom: basic.Point{11.3, 12.7},
+		},
+		{
+			geom:         basic.Point3{10.3, 11.7, 8},
+			expectedGeom: basic.Point3{11.3, 12.7, 9},
+		},
+		{
+			geom:         basic.Line{basic.Point{3.3, 3.3}, basic.Point{4.4, 4.4}, basic.Point{5.5, 5.5}},
+			expectedGeom: basic.Line{basic.Point{4.3, 4.3}, basic.Point{5.4, 5.4}, basic.Point{6.5, 6.5}},
+		},
+		{
+			geom: basic.Polygon{basic.Line{
+				basic.Point{3.3, 3.3}, basic.Point{4.4, 4.4}, basic.Point{5.5, 5.5},
+				basic.Point{5.5, 3.3}, basic.Point{3.3, 3.3}},
+			},
+			expectedGeom: basic.Polygon{basic.Line{
+				basic.Point{4.3, 4.3}, basic.Point{5.4, 5.4}, basic.Point{6.5, 6.5},
+				basic.Point{6.5, 4.3}, basic.Point{4.3, 4.3}},
+			},
+		},
+		{
+			geom:         basic.MultiPoint{basic.Point{10.10, 11.11}, basic.Point{11.11, 12.12}},
+			expectedGeom: basic.MultiPoint{basic.Point{11.10, 12.11}, basic.Point{12.11, 13.12}},
+		},
+		{
+			geom:         basic.MultiPoint3{basic.Point3{10.10, 11.11, 3}, basic.Point3{11.11, 12.12, 3}},
+			expectedGeom: basic.MultiPoint3{basic.Point3{11.10, 12.11, 4}, basic.Point3{12.11, 13.12, 4}},
+		},
+		{
+			geom: basic.MultiLine{
+				basic.Line{basic.Point{3.3, 3.3}, basic.Point{4.4, 4.4}, basic.Point{5.5, 5.5}},
+				basic.Line{basic.Point{6.6, 6.6}, basic.Point{5.5, 5.5}, basic.Point{4.4, 4.4}},
+			},
+			expectedGeom: basic.MultiLine{
+				basic.Line{basic.Point{4.3, 4.3}, basic.Point{5.4, 5.4}, basic.Point{6.5, 6.5}},
+				basic.Line{basic.Point{7.6, 7.6}, basic.Point{6.5, 6.5}, basic.Point{5.4, 5.4}},
+			},
+		},
+		{
+			geom: basic.MultiPolygon{
+				basic.Polygon{
+					basic.Line{
+						basic.Point{1.1, 1.1}, basic.Point{2.2, 2.2}, basic.Point{3.3, 3.3},
+						basic.Point{3.3, 1.1}, basic.Point{1.1, 1.1}},
+				},
+			},
+			expectedGeom: basic.MultiPolygon{
+				basic.Polygon{
+					basic.Line{
+						basic.Point{2.1, 2.1}, basic.Point{3.2, 3.2}, basic.Point{4.3, 4.3},
+						basic.Point{4.3, 2.1}, basic.Point{2.1, 2.1}},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		resultG, err := basic.ApplyToPoints(tc.geom, inc)
+		if err != nil {
+			t.Errorf("[%v] Problem with basic.ApplyToPoints(): %v", i, err)
+		}
+		switch {
+		case resultG.IsPoint():
+			resultPoint := resultG.AsPoint()
+			expectedPoint := tc.expectedGeom.(basic.Point)
+			if !basic.PointsEqual(resultPoint, expectedPoint, floatDelta) {
+				t.Errorf("[%v] Point returned doesn't match expected: %v != %v", i, resultPoint, expectedPoint)
+			}
+		case resultG.IsPoint3():
+			resultPoint := resultG.AsPoint3()
+			expectedPoint := tc.expectedGeom.(basic.Point3)
+			if !basic.Point3sEqual(resultPoint, expectedPoint, floatDelta) {
+				t.Errorf("[%v] Point returned doesn't match expected: %v != %v", i, resultPoint, expectedPoint)
+			}
+		case resultG.IsLine():
+			resultLine := resultG.AsLine()
+			expectedLine := tc.expectedGeom.(basic.Line)
+			if !basic.LinesEqual(resultLine, expectedLine, floatDelta) {
+				t.Errorf("[%v] Line returned doesn't match expected: %v != %v", i, resultLine, expectedLine)
+			}
+		case resultG.IsPolygon():
+			resultPoly := resultG.AsPolygon()
+			expectedPoly := tc.expectedGeom.(basic.Polygon)
+			if !basic.PolygonsEqual(resultPoly, expectedPoly, floatDelta) {
+				t.Errorf("[%v] Polygon returned doesn't match expected: %v != %v", i, resultPoly, expectedPoly)
+			}
+		case resultG.IsMultiPoint():
+			resultMP := resultG.AsMultiPoint()
+			expectedMP := tc.expectedGeom.(basic.MultiPoint)
+			if !basic.MultiPointsEqual(resultMP, expectedMP, floatDelta) {
+				t.Errorf("[%v] MultiPoint returned doesn't match expected: %v != %v", i, resultMP, expectedMP)
+			}
+		case resultG.IsMultiPoint3():
+			resultMP3 := resultG.AsMultiPoint3()
+			expectedMP3 := tc.expectedGeom.(basic.MultiPoint3)
+			if !basic.MultiPoint3sEqual(resultMP3, expectedMP3, floatDelta) {
+				t.Errorf("[%v] MultiPoint3 returned doesn't match expected: %v != %v", i, resultMP3, expectedMP3)
+			}
+		case resultG.IsMultiLine():
+			resultML := resultG.AsMultiLine()
+			expectedML := tc.expectedGeom.(basic.MultiLine)
+			if !basic.MultiLinesEqual(resultML, expectedML, floatDelta) {
+				t.Errorf("[%v] MultiLine returned doesn't match expected: %v != %v", i, resultML, expectedML)
+			}
+		case resultG.IsMultiPolygon():
+			resultMPoly := resultG.AsMultiPolygon()
+			expectedMPoly := tc.expectedGeom.(basic.MultiPolygon)
+			if !basic.MultiPolygonsEqual(resultMPoly, expectedMPoly, floatDelta) {
+				t.Errorf("[%v] MultiPolygon returned doesn't match expected: %v != %v", i, resultMPoly, expectedMPoly)
+			}
+		}
+	}
+}

--- a/basic/line.go
+++ b/basic/line.go
@@ -117,6 +117,19 @@ func (l Line) Subpoints() (points []tegola.Point) {
 // MultiLine is a set of lines.
 type MultiLine []Line
 
+// Checks that ml1 == ml2 with coordinates within delta
+func MultiLinesEqual(ml1, ml2 MultiLine, delta float64) bool {
+	if len(ml1) != len(ml2) {
+		return false
+	}
+	for i := 0; i < len(ml1); i++ {
+		if !LinesEqual(ml1[i], ml2[i], delta) {
+			return false
+		}
+	}
+	return true
+}
+
 func NewMultiLine(pointPairLines ...[]float64) (ml MultiLine) {
 	for _, pp := range pointPairLines {
 		ml = append(ml, NewLine(pp...))

--- a/basic/line.go
+++ b/basic/line.go
@@ -12,6 +12,21 @@ import (
 // TODO: We don't really check to make sure the points don't intersect.
 type Line []Point
 
+func LinesEqual(l1 Line, l2 Line, delta float64) (equal bool) {
+	// Checks if points from each line are equal with coordinates within delta of each other.
+	if len(l1) != len(l2) {
+		return false
+	}
+
+	for i := 0; i < len(l1); i++ {
+		if !PointsEqual(l1[i], l2[i], delta) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Just to make basic collection only usable with basic types.
 func (Line) basicType()                      {}
 func (Line) String() string                  { return "Line" }

--- a/basic/point.go
+++ b/basic/point.go
@@ -2,10 +2,19 @@ package basic
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/terranodo/tegola"
 	"github.com/terranodo/tegola/maths"
 )
+
+func PointsEqual(p1 Point, p2 Point, delta float64) (equal bool) {
+	// Checks if p1 == p2 within floatDelta for each coordinate.
+	if math.Abs(p1[0]-p2[0]) < delta && math.Abs(p1[1]-p2[1]) < delta {
+		equal = true
+	}
+	return equal
+}
 
 // Point describes a simple 2d point
 type Point [2]float64

--- a/basic/point.go
+++ b/basic/point.go
@@ -47,6 +47,14 @@ func (p Point) String() string {
 // Point3 describes a simple 3d point
 type Point3 [3]float64
 
+func Point3sEqual(p1, p2 Point3, delta float64) (equal bool) {
+	// Checks if p1 == p2 within floatDelta for each coordinate.
+	if math.Abs(p1[0]-p2[0]) < delta && math.Abs(p1[1]-p2[1]) < delta && math.Abs(p1[2]-p2[2]) < delta {
+		equal = true
+	}
+	return equal
+}
+
 // Just to make basic collection only usable with basic types.
 func (Point3) basicType() {}
 
@@ -54,6 +62,7 @@ func (Point3) basicType() {}
 func (bp Point3) X() float64 {
 	return bp[0]
 }
+
 func (p Point3) String() string {
 	return fmt.Sprintf("Point3(%v,%v,%v)", p[0], p[1], p[2])
 }
@@ -71,6 +80,19 @@ func (bp Point3) Z() float64 {
 // MultiPoint describes a simple set of 2d points
 type MultiPoint []Point
 
+// Checks that mp1 == mp2 with coordinates within delta.
+func MultiPointsEqual(mp1, mp2 MultiPoint, delta float64) bool {
+	if len(mp1) != len(mp2) {
+		return false
+	}
+	for i := 0; i < len(mp1); i++ {
+		if !PointsEqual(mp1[i], mp2[i], delta) {
+			return false
+		}
+	}
+	return true
+}
+
 // Just to make basic collection only usable with basic types.
 func (MultiPoint) basicType()     {}
 func (MultiPoint) String() string { return "MultiPoint" }
@@ -86,11 +108,24 @@ func (v MultiPoint) Points() (points []tegola.Point) {
 // MultiPoint3 describes a simple set of 3d points
 type MultiPoint3 []Point3
 
+// Checks that mp3a == mp3b with coordinates within delta.
+func MultiPoint3sEqual(mp3a, mp3b MultiPoint3, delta float64) bool {
+	if len(mp3a) != len(mp3b) {
+		return false
+	}
+	for i := 0; i < len(mp3a); i++ {
+		if !Point3sEqual(mp3a[i], mp3b[i], delta) {
+			return false
+		}
+	}
+	return true
+}
+
 // Just to make basic collection only usable with basic types.
 func (MultiPoint3) basicType() {}
 
 // Points are the points that make up the set
-func (v MultiPoint3) Points() (points []tegola.Point) {
+func (v MultiPoint3) Points() (points []tegola.Point3) {
 	for i := range v {
 		points = append(points, v[i])
 	}

--- a/basic/polygon.go
+++ b/basic/polygon.go
@@ -19,6 +19,7 @@ func (p Polygon) Sublines() (slines []tegola.LineString) {
 	}
 	return slines
 }
+
 func (Polygon) String() string {
 	return "Polygon"
 }

--- a/basic/polygon.go
+++ b/basic/polygon.go
@@ -8,6 +8,22 @@ import (
 // Polygon describes a basic polygon; made up of multiple lines.
 type Polygon []Line
 
+func PolygonsEqual(p1, p2 Polygon, delta float64) bool {
+	if len(p1.Sublines()) != len(p2.Sublines()) {
+		return false
+	}
+
+	for i := 0; i < len(p1.Sublines()); i++ {
+		l1 := p1.Sublines()[i].(Line)
+		l2 := p2.Sublines()[i].(Line)
+		if !LinesEqual(l1, l2, delta) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Just to make basic collection only usable with basic types.
 func (Polygon) basicType() {}
 
@@ -26,6 +42,23 @@ func (Polygon) String() string {
 
 // MultiPolygon describes a set of polygons.
 type MultiPolygon []Polygon
+
+// Checks for mp1 == mp2 with coordinate values within delta
+func MultiPolygonsEqual(mp1, mp2 MultiPolygon, delta float64) bool {
+	if len(mp1.Polygons()) != len(mp2.Polygons()) {
+		return false
+	}
+
+	for i := 0; i < len(mp1.Polygons()); i++ {
+		p1 := mp1.Polygons()[i].(Polygon)
+		p2 := mp2.Polygons()[i].(Polygon)
+		if !PolygonsEqual(p1, p2, delta) {
+			return false
+		}
+	}
+
+	return true
+}
 
 // Just to make basic collection only usable with basic types.
 func (MultiPolygon) basicType() {}

--- a/geometry.go
+++ b/geometry.go
@@ -30,6 +30,12 @@ type MultiPoint interface {
 	Points() []Point
 }
 
+// MultiPoint is a Geometry with multiple individual points.
+type MultiPoint3 interface {
+	Geometry
+	Points() []Point3
+}
+
 // LineString is a Geometry of a line.
 type LineString interface {
 	Geometry

--- a/maths/webmercator/pseudo_test.go
+++ b/maths/webmercator/pseudo_test.go
@@ -16,8 +16,8 @@ func float64Equal(f1, f2, delta float64) (equal bool) {
 }
 
 func TestPToLonLat(t *testing.T) {
-	// Acceptable fuzziness in equality between floats
-	floatDelta := 0.00001
+	// Acceptable fuzziness in equality between longitude/latitude float values
+	floatDelta := 0.00000001
 
 	// Expected values according to 'https://mygeodata.cloud/cs2cs/' and/or 'https://twcc.fr/#'
 	type TestCase struct {
@@ -70,6 +70,65 @@ func TestPToLonLat(t *testing.T) {
 
 			t.Errorf("[%v] Converted (lng,lat) doesn't match expected: (%v,%v) != (%v,%v)",
 				i, resultLng, resultLat, tc.expectedLng, tc.expectedLat)
+		}
+	}
+}
+
+func TestPToXY(t *testing.T) {
+	// Acceptable fuzziness in equality between x,y float values
+	floatDelta := 0.001
+
+	// Expected values according to 'https://mygeodata.cloud/cs2cs/' and/or 'https://twcc.fr/#'
+	type TestCase struct {
+		// longitude, latitude
+		lng float64
+		lat float64
+		// Expected x, y
+		expectedX float64
+		expectedY float64
+	}
+
+	testCases := []TestCase{
+		{
+			lng:       -144.84375,
+			lat:       -72.18180355624852,
+			expectedX: -16123932.495,
+			expectedY: -11818999.062,
+		},
+		{
+			lng:       137.8125,
+			lat:       -49.38237278700955,
+			expectedX: 15341217.325,
+			expectedY: -6339992.874,
+		},
+		{
+			lng:       140.2734375,
+			lat:       59.355596110016315,
+			expectedX: 15615167.634,
+			expectedY: 8257645.04,
+		},
+		{
+			lng:       -101.6015625,
+			lat:       56.75272287205736,
+			expectedX: -11310234.201,
+			expectedY: 7709744.421,
+		},
+	}
+
+	for i, tc := range testCases {
+		var resultXY []float64
+		resultXY, err := webmercator.PToXY(tc.lng, tc.lat)
+		if err != nil {
+			t.Errorf("[%v] Error in webmercator.PToLonLat(): %v", i, err)
+		}
+
+		resultX := resultXY[0]
+		resultY := resultXY[1]
+		if !float64Equal(resultX, tc.expectedX, floatDelta) ||
+			!float64Equal(resultY, tc.expectedY, floatDelta) {
+
+			t.Errorf("[%v] Converted (x,y) doesn't match expected: (%v,%v) != (%v,%v)",
+				i, resultX, resultY, tc.expectedX, tc.expectedY)
 		}
 	}
 }

--- a/maths/webmercator/pseudo_test.go
+++ b/maths/webmercator/pseudo_test.go
@@ -1,0 +1,75 @@
+package webmercator_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/terranodo/tegola/maths/webmercator"
+)
+
+func float64Equal(f1, f2, delta float64) (equal bool) {
+	// Checks if f1 == f2 within a difference of delta
+	if math.Abs(f1-f2) < delta {
+		return true
+	}
+	return false
+}
+
+func TestPToLonLat(t *testing.T) {
+	// Acceptable fuzziness in equality between floats
+	floatDelta := 0.00001
+
+	// Expected values according to 'https://mygeodata.cloud/cs2cs/' and/or 'https://twcc.fr/#'
+	type TestCase struct {
+		// WebMercator x, y
+		wmX float64
+		wmY float64
+		// Expected longitude, latitude
+		expectedLng float64
+		expectedLat float64
+	}
+
+	testCases := []TestCase{
+		{
+			wmX:         -16123932.495,
+			wmY:         -11818999.062,
+			expectedLng: -144.84375,
+			expectedLat: -72.18180355624852,
+		},
+		{
+			wmX:         15341217.325,
+			wmY:         -6339992.874,
+			expectedLng: 137.8125,
+			expectedLat: -49.38237278700955,
+		},
+		{
+			wmX:         15615167.634,
+			wmY:         8257645.04,
+			expectedLng: 140.2734375,
+			expectedLat: 59.355596110016315,
+		},
+		{
+			wmX:         -11310234.201,
+			wmY:         7709744.421,
+			expectedLng: -101.6015625,
+			expectedLat: 56.75272287205736,
+		},
+	}
+
+	for i, tc := range testCases {
+		var resultLngLat []float64
+		resultLngLat, err := webmercator.PToLonLat(tc.wmX, tc.wmY)
+		if err != nil {
+			t.Errorf("[%v] Error in webmercator.PToLonLat(): %v", i, err)
+		}
+
+		resultLng := resultLngLat[0]
+		resultLat := resultLngLat[1]
+		if !float64Equal(resultLng, tc.expectedLng, floatDelta) ||
+			!float64Equal(resultLat, tc.expectedLat, floatDelta) {
+
+			t.Errorf("[%v] Converted (lng,lat) doesn't match expected: (%v,%v) != (%v,%v)",
+				i, resultLng, resultLat, tc.expectedLng, tc.expectedLat)
+		}
+	}
+}

--- a/provider/postgis/util_internal_test.go
+++ b/provider/postgis/util_internal_test.go
@@ -22,7 +22,7 @@ func TestReplaceTokens(t *testing.T) {
 				X: 1,
 				Y: 1,
 			},
-			expected: "SELECT * FROM foo WHERE geom && ST_MakeEnvelope(-1.001875417e+07,1.001875417e+07,0,0,3857)",
+			expected: "SELECT * FROM foo WHERE geom && ST_MakeEnvelope(-1.001875417e+07,0,0,1.001875417e+07,3857)",
 		},
 		{
 			layer: Layer{
@@ -34,7 +34,7 @@ func TestReplaceTokens(t *testing.T) {
 				X: 1,
 				Y: 1,
 			},
-			expected: "SELECT id, scalerank=2 FROM foo WHERE geom && ST_MakeEnvelope(-1.001875417e+07,1.001875417e+07,0,0,3857)",
+			expected: "SELECT id, scalerank=2 FROM foo WHERE geom && ST_MakeEnvelope(-1.001875417e+07,0,0,1.001875417e+07,3857)",
 		},
 	}
 

--- a/tile.go
+++ b/tile.go
@@ -46,9 +46,9 @@ func (t *Tile) BoundingBox() BoundingBox {
 
 	return BoundingBox{
 		Minx:    -max + (float64(t.X) * res),
-		Miny:    max - (float64(t.Y) * res),
+		Miny:    max - (float64(t.Y) * res) - res,
 		Maxx:    -max + (float64(t.X) * res) + res,
-		Maxy:    max - (float64(t.Y) * res) - res,
+		Maxy:    max - (float64(t.Y) * res),
 		Epsilon: t.ZEpislon(),
 		HasXYZ:  true,
 		X:       t.X,

--- a/tile_test.go
+++ b/tile_test.go
@@ -76,9 +76,9 @@ func TestTileBBox(t *testing.T) {
 				Y: 1,
 			},
 			minx: -10018754.17,
-			miny: 10018754.17,
+			miny: 0,
 			maxx: 0,
-			maxy: 0,
+			maxy: 10018754.17,
 		},
 		{
 			tile: tegola.Tile{
@@ -87,9 +87,9 @@ func TestTileBBox(t *testing.T) {
 				Y: 26461,
 			},
 			minx: -13044437.497219238996,
-			miny: 3856706.6986199953,
+			miny: 3856095.202393799,
 			maxx: -13043826.000993041,
-			maxy: 3856095.202393799,
+			maxy: 3856706.6986199953,
 		},
 	}
 


### PR DESCRIPTION
Adds tests for a number of conversion functions, verifying WebMercator values.
Swaps the position of Tile.BoundingBox() y-values so the smaller of the two is placed in Miny.
