### PR TITLE
Reject PostGIS layers with type ST_GeometryCollection

### DIFF
--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -319,8 +319,6 @@ func (p Provider) layerGeomType(l *Layer) error {
 					l.geomType = geom.MultiLineString{}
 				case "ST_MultiPolygon":
 					l.geomType = geom.MultiPolygon{}
-				case "ST_GeometryCollection":
-					l.geomType = geom.Collection{}
 				default:
 					return fmt.Errorf("layer (%v) returned unsupported geometry type (%v)", l.name, v)
 				}


### PR DESCRIPTION
I note from #204 that this isn't supported, but for some reason the PostGIS driver accepts it, which caused me some confusion.

I'm diffing against the v0.6.0 branch at the moment, so prod me to rebase if that gets released.