### PR TITLE
Typo, grammar, clarity fixes.

### DIFF
--- a/cache/file/README.md
+++ b/cache/file/README.md
@@ -1,6 +1,6 @@
 # FileCache
 
-File cache uses a file system for cachine tiles. To use use it, add the following minimum config ot your tegola config file:
+filecache uses a file system for caching tiles. To use it, add the following minimum config to your tegola config file:
 
 ```toml
 [cache]
@@ -9,7 +9,7 @@ basepath="/tmp/tegola-cache"
 ```
 
 ## Properties
-The s3cache config supports the following properties:
+The filecache config supports the following properties:
 
 - `basepath` (string): [Required] a location on the file system to write the cached tiles to.
 - `max_zoom` (int): [Optional] the max zoom the cache should cache to. After this zoom, Set() calls will return before doing work.

--- a/cache/redis/README.md
+++ b/cache/redis/README.md
@@ -1,6 +1,6 @@
 # RedisCache
 
-This package implement's tegola's cache interface for use with Redis. If a redis instance is running locally with default configurations solely for tegola simply include the following snippet in tegola's config file:
+This package implements tegola's cache interface for use with Redis. If a redis instance is running locally with default configurations solely for tegola simply include the following snippet in tegola's config file:
 
 ```toml
 [cache]


### PR DESCRIPTION
A few cleanups for the cache types documentation.