### PR TITLE
wkb/encoding package: check if Byte Order Marker is correctly set before processing stream

### DIFF
--- a/geom/encoding/wkb/internal/decode/decode.go
+++ b/geom/encoding/wkb/internal/decode/decode.go
@@ -16,10 +16,14 @@ func ByteOrderType(r io.Reader) (byteOrder binary.ByteOrder, typ uint32, err err
 		return byteOrder, typ, err
 	}
 
-	if bom[0] == 0 {
+	// the bom should be either 0 or 1
+	switch bom[0] {
+	case 0:
 		byteOrder = binary.BigEndian
-	} else {
+	case 1:
 		byteOrder = binary.LittleEndian
+	default:
+		return byteOrder, typ, fmt.Errorf("Byte Order Marker should be 0 or 1; got %v instead.", bom[0])
 	}
 
 	// Reading the type which is 4 bytes


### PR DESCRIPTION
One of the errors detected by fuzzing (#53, #384) was the creation of valid geometries from corrupt data. This patch goes some ways to remedying this by checking if the BOM is correctly set (0 or 1) as per the specification and returning an error if it is any other value. 