### PR TITLE
Issue 435 & 422: filecache: on Windows files are written with invalid names

### DIFF
--- a/cache/file/file.go
+++ b/cache/file/file.go
@@ -118,7 +118,6 @@ func (fc *Cache) Set(key *cache.Key, val []byte) error {
 	if err != nil {
 		return err
 	}
-	//defer f.Close()
 
 	// copy the contents
 	_, err = f.Write(val)

--- a/cache/file/file.go
+++ b/cache/file/file.go
@@ -118,11 +118,18 @@ func (fc *Cache) Set(key *cache.Key, val []byte) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	//defer f.Close()
 
 	// copy the contents
 	_, err = f.Write(val)
 	if err != nil {
+		// close the file, can't use 'defer f.Close()'' otherwise rename wont happen
+		f.Close()
+		return err
+	}
+
+	// close the file, can't use 'defer f.Close()'' otherwise rename wont happen
+	if err = f.Close(); err != nil {
 		return err
 	}
 

--- a/cache/file/file_test.go
+++ b/cache/file/file_test.go
@@ -137,7 +137,7 @@ func TestSetGetPurge(t *testing.T) {
 				X: 1,
 				Y: 2,
 			},
-			expected: []byte("\x53\x69\x6c\x61\x73"),
+			expected: []byte{0x53, 0x69, 0x6c, 0x61, 0x73},
 		},
 	}
 
@@ -212,9 +212,9 @@ func TestSetOverwrite(t *testing.T) {
 				X: 1,
 				Y: 1,
 			},
-			bytes1:   []byte("\x66\x6f\x6f"),
-			bytes2:   []byte("\x53\x69\x6c\x61\x73"),
-			expected: []byte("\x53\x69\x6c\x61\x73"),
+			bytes1:   []byte{0x66, 0x6f, 0x6f},
+			bytes2:   []byte{0x53, 0x69, 0x6c, 0x61, 0x73},
+			expected: []byte{0x53, 0x69, 0x6c, 0x61, 0x73},
 		},
 	}
 
@@ -280,7 +280,7 @@ func TestMaxZoom(t *testing.T) {
 				X: 1,
 				Y: 1,
 			},
-			bytes:       []byte("\x66\x6f\x6f"),
+			bytes:       []byte{0x66, 0x6f, 0x6f},
 			expectedHit: false,
 		},
 		"under max zoom": {
@@ -293,7 +293,7 @@ func TestMaxZoom(t *testing.T) {
 				X: 1,
 				Y: 1,
 			},
-			bytes:       []byte("\x66\x6f\x6f"),
+			bytes:       []byte{0x66, 0x6f, 0x6f},
 			expectedHit: true,
 		},
 		"equals max zoom": {
@@ -306,7 +306,7 @@ func TestMaxZoom(t *testing.T) {
 				X: 1,
 				Y: 1,
 			},
-			bytes:       []byte("\x66\x6f\x6f"),
+			bytes:       []byte{0x66, 0x6f, 0x6f},
 			expectedHit: true,
 		},
 	}


### PR DESCRIPTION
Good find @TNT0305!