### PR TITLE
Issue 445 env package not properly parsing slices

### DIFF
--- a/internal/env/dict.go
+++ b/internal/env/dict.go
@@ -18,11 +18,11 @@ func (d Dict) Dict(key string) (v Dict, err error) {
 	var dv Dict
 	var ok bool
 	if val, ok = d[key]; !ok {
-		return v, fmt.Errorf("%v value is required.", key)
+		return v, dict.ErrKeyRequired(key)
 	}
 
 	if dv, ok = val.(Dict); !ok {
-		return v, fmt.Errorf("%v value needs to be of type map[string]interface{}.", key)
+		return v, dict.ErrKeyType{Key: key, Value: val, T:reflect.TypeOf(v)}
 	}
 	return dv, nil
 }
@@ -86,8 +86,9 @@ func (d Dict) StringSlice(key string) (v []string, err error) {
 			if iv[k] == nil {
 				v[k] = ""
 			} else {
-				ptr, err := ParseString(val)
+				ptr, err := ParseString(iv[k])
 				if err != nil {
+					fmt.Println("err", err)
 					switch err.(type) {
 					case ErrEnvVar:
 						return v, err
@@ -163,7 +164,7 @@ func (d Dict) BoolSlice(key string) (v []bool, err error) {
 			if iv[k] == nil {
 				iv[k] = false
 			} else {
-				ptr, err := ParseBool(val)
+				ptr, err := ParseBool(iv[k])
 				if err != nil {
 					switch err.(type) {
 					case ErrEnvVar:
@@ -238,7 +239,7 @@ func (d Dict) IntSlice(key string) (v []int, err error) {
 			if iv[k] == nil {
 				iv[k] = 0
 			} else {
-				ptr, err := ParseInt(val)
+				ptr, err := ParseInt(iv[k])
 				if err != nil {
 					switch err.(type) {
 					case ErrEnvVar:
@@ -309,11 +310,12 @@ func (d Dict) UintSlice(key string) (v []uint, err error) {
 			// Could not convert to the generic type, so we don't have the correct thing.
 			return v, &ErrType{val}
 		}
+		v = make([]uint, len(iv))
 		for k := range iv {
 			if iv[k] == nil {
 				iv[k] = 0
 			} else {
-				ptr, err := ParseUint(val)
+				ptr, err := ParseUint(iv[k])
 				if err != nil {
 					switch err.(type) {
 					case ErrEnvVar:
@@ -382,11 +384,12 @@ func (d Dict) FloatSlice(key string) (v []float64, err error) {
 			// Could not convert to the generic type, so we don't have the correct thing.
 			return v, &ErrType{val}
 		}
+		v = make([]float64, len(iv))
 		for k := range iv {
 			if iv[k] == nil {
 				iv[k] = 0
 			} else {
-				ptr, err := ParseFloat(val)
+				ptr, err := ParseFloat(iv[k])
 				if err != nil {
 					switch err.(type) {
 					case ErrEnvVar:

--- a/internal/env/dict_test.go
+++ b/internal/env/dict_test.go
@@ -418,6 +418,76 @@ func TestDict(t *testing.T) {
 			key:      "float_slice",
 			expected: []float64{},
 		},
+		"iface to string": {
+			dict: env.Dict{
+				"interface": interface{}("hello"),
+			},
+			key:"interface",
+			expected: "hello",
+		},
+		"iface to bool": {
+			dict: env.Dict{
+				"interface": interface{}(true),
+			},
+			key:"interface",
+			expected: true,
+		},
+		"iface to int": {
+			dict: env.Dict{
+				"interface": interface{}(int(-25)),
+			},
+			key:"interface",
+			expected: int(-25),
+		},
+		"iface to uint": {
+			dict: env.Dict{
+				"interface": interface{}(uint(42)),
+			},
+			key:"interface",
+			expected: uint(42),
+		},
+		"iface to float": {
+			dict: env.Dict{
+				"interface": interface{}(-25e-10),
+			},
+			key:"interface",
+			expected: -25e-10,
+		},
+		"iface slice to string slice": {
+			dict: env.Dict{
+				"interface_slice": []interface{}{"hello", "world"},
+			},
+			key:"interface_slice",
+			expected: []string{"hello", "world"},
+		},
+		"iface slice to bool slice": {
+			dict: env.Dict{
+				"interface_slice": []interface{}{true, false, false},
+			},
+			key:"interface_slice",
+			expected: []bool{true, false, false},
+		},
+		"iface slice to int slice": {
+			dict: env.Dict{
+				"interface_slice": []interface{}{int(42), int(-25), int(1970)},
+			},
+			key:"interface_slice",
+			expected: []int{42, -25, 1970},
+		},
+		"iface slice to uint slice": {
+			dict: env.Dict{
+				"interface_slice": []interface{}{uint(42), uint(25), uint(1970)},
+			},
+			key:"interface_slice",
+			expected: []uint{42, 25, 1970},
+		},
+		"iface slice to float slice": {
+			dict: env.Dict{
+				"interface_slice": []interface{}{float64(42.0), float64(-25e-10), float64(1.970e4)},
+			},
+			key:"interface_slice",
+			expected: []float64{42.0, -25e-10, 1.970e4},
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
For my explanation, the letter "T" represents all types ("string", "bool", "int", etc.)

The error was a result of passing the `[]interface{}` into `ParseT()` vs a single element from the `[]interface{}`. Also added tests for converting from `[]interface{}`to `[]T` and `interface{}` to `T`