### PR TITLE
postgis: add support for !bbox! (Mapnik) and !BOX! (MapServer) tokens

### DIFF
--- a/provider/postgis/README.md
+++ b/provider/postgis/README.md
@@ -44,8 +44,8 @@ tablename = "gis.zoning_base_3857"
 - `fields` ([]string): [Optional] a list of fields to include alongside the feature. Can be used if `sql` is not defined.
 - `srid` (int): [Optional] the SRID of the layer. Supports `3857` (WebMercator) or `4326` (WGS84).
 - `sql` (string): [*Required] custom SQL to use use. Required if `tablename` is not defined. Supports the following tokens:
-  - !BBOX! - [Required] will be replaced with the bounding box of the tile before the query is sent to the database.
-  - !ZOOM! - [Optional] will be replaced with the "Z" (zoom) value of the requested tile.
+  - `!BBOX!` - [Required] will be replaced with the bounding box of the tile before the query is sent to the database. `!bbox!` and`!BOX!` are supported as well for compatibilitiy with queries from Mapnik and MapServer styles.
+  - `!ZOOM!` - [Optional] will be replaced with the "Z" (zoom) value of the requested tile.
 
 
 `*Required`: either the `tablename` or `sql` must be defined, but not both.

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -219,6 +219,8 @@ func NewTileProvider(config map[string]interface{}) (provider.Tiler, error) {
 			srid:      uint64(lsrid),
 		}
 		if sql != "" {
+			// convert !BOX! (MapServer) and !bbox! (Mapnik) to !BBOX! for compatibility
+			sql := strings.Replace(strings.Replace(sql, "!BOX!", "!BBOX!", -1), "!bbox!", "!BBOX!", -1)
 			// make sure that the sql has a !BBOX! token
 			if !strings.Contains(sql, bboxToken) {
 				return nil, fmt.Errorf("SQL for layer (%v) %v is missing required token: %v", i, lname, bboxToken)


### PR DESCRIPTION
Replacing both variations to !BBOX! on init, to avoid conversion for each request.

Closes #443