### PR TITLE
enable Go pprof profiler with TEGOLA_HTTP_PPROF environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ The following build flags can be used to turn off certain features of tegola:
 - `noPostgisProvider` - turn off the PostGIS data provider.
 - `noGpkgProvider` - turn off the GeoPackage data provider. Note, GeoPackage uses CGO and will be turned off if the environment variable `CGO_ENABLED=0` is set prior to building.
 - `noViewer` - turn off the built in viewer.
+- `pprof` - enable [Go profiler](https://golang.org/pkg/net/http/pprof/). Start profile server by setting the environment `TEGOLA_HTTP_PPROF_BIND` environment (e.g. `TEGOLA_HTTP_PPROF_BIND=localhost:6060`).
 
 Example of using the build flags to turn of the Redis cache back end, the GeoPackage provider and the built in viewer.
 

--- a/cmd/tegola/pprof.go
+++ b/cmd/tegola/pprof.go
@@ -1,0 +1,33 @@
+// +build pprof
+
+package main
+
+// The point of this file is to load the Go profiler.
+// You need to compile Tegola with `go build -tags 'pprof'` and you need to
+// enabled it by setting the TEGOLA_HTTP_PPROF_BIND environment to a
+// hostname:port combination (e.g. TEGOLA_HTTP_PPROF_BIND=localhost:6060).
+
+// To show 30s CPU profile:
+//   % go tool pprof -web http://localhost:6060/debug/pprof/profile
+// To show all allocated space:
+//   % go tool pprof -alloc_space -web http://localhost:6060/debug/pprof/heap
+
+// The profiler can be completely disabled during the build with the `noPprof` build flag
+// for example from the cmd/tegola direcotry:
+//
+// go build -tags 'noPprof'
+
+import (
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+)
+
+func init() {
+	if bind := os.Getenv("TEGOLA_HTTP_PPROF_BIND"); bind != "" {
+		go func() {
+			log.Fatal(http.ListenAndServe(bind, nil))
+		}()
+	}
+}


### PR DESCRIPTION
Allow to use Go's pprof profiler.

This should have no measurable impact when not enabled via ``TEGOLA_HTTP_PPROF``, but I did not found any reliable source for that.

I added a build flag anyway, but can remove it or flip the default (i.e. make it `+build pprof`).