### PR TITLE
provider/postgis: add geometry_type option to avoid table inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ ssl_mode = "prefer"        # PostgreSQL SSL mode*. Default is "disable". (option
 	name = "roads"                      # will be encoded as the layer name in the tile
 	tablename = "gis.zoning_base_3857"  # sql or table_name are required
 	geometry_fieldname = "geom"         # geom field. default is geom
+	geometry_type = "linestring"        # geometry type. Tables are inspected at startup, if not set.
 	id_fieldname = "gid"                # geom id field. default is gid
 	fields = [ "class", "name" ]        # Additional fields to include in the select statement.
 

--- a/provider/postgis/postgis_internal_test.go
+++ b/provider/postgis/postgis_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/go-spatial/geom"
@@ -27,13 +28,33 @@ func TestLayerGeomType(t *testing.T) {
 	port := GetTestPort(t)
 
 	type tcase struct {
-		config    dict.Dict
+		config    map[string]interface{}
 		layerName string
 		geom      geom.Geometry
+		err       string
 	}
 
 	fn := func(t *testing.T, tc tcase) {
-		provider, err := NewTileProvider(tc.config)
+		var config dict.Dict
+		config = map[string]interface{}{
+			ConfigKeyHost:        os.Getenv("PGHOST"),
+			ConfigKeyPort:        port,
+			ConfigKeyDB:          os.Getenv("PGDATABASE"),
+			ConfigKeyUser:        os.Getenv("PGUSER"),
+			ConfigKeyPassword:    os.Getenv("PGPASSWORD"),
+			ConfigKeySSLMode:     os.Getenv("PGSSLMODE"),
+			ConfigKeySSLKey:      os.Getenv("PGSSLKEY"),
+			ConfigKeySSLCert:     os.Getenv("PGSSLCERT"),
+			ConfigKeySSLRootCert: os.Getenv("PGSSLROOTCERT"),
+		}
+		config[ConfigKeyLayers] = []map[string]interface{}{tc.config}
+		provider, err := NewTileProvider(config)
+		if tc.err != "" {
+			if err == nil || !strings.Contains(err.Error(), tc.err) {
+				t.Errorf("expected error with %q in NewProvicer, got: %v", tc.err, err)
+			}
+			return
+		}
 		if err != nil {
 			t.Errorf("NewProvider unexpected error: %v", err)
 			return
@@ -41,10 +62,6 @@ func TestLayerGeomType(t *testing.T) {
 
 		p := provider.(Provider)
 		layer := p.layers[tc.layerName]
-		if err := p.layerGeomType(&layer); err != nil {
-			t.Errorf("layerGeomType unexpected error: %v", err)
-			return
-		}
 
 		if !reflect.DeepEqual(tc.geom, layer.geomType) {
 			t.Errorf("geom type, expected %v got %v", tc.geom, layer.geomType)
@@ -55,44 +72,46 @@ func TestLayerGeomType(t *testing.T) {
 	tests := map[string]tcase{
 		"1": {
 			config: map[string]interface{}{
-				ConfigKeyHost:        os.Getenv("PGHOST"),
-				ConfigKeyPort:        port,
-				ConfigKeyDB:          os.Getenv("PGDATABASE"),
-				ConfigKeyUser:        os.Getenv("PGUSER"),
-				ConfigKeyPassword:    os.Getenv("PGPASSWORD"),
-				ConfigKeySSLMode:     os.Getenv("PGSSLMODE"),
-				ConfigKeySSLKey:      os.Getenv("PGSSLKEY"),
-				ConfigKeySSLCert:     os.Getenv("PGSSLCERT"),
-				ConfigKeySSLRootCert: os.Getenv("PGSSLROOTCERT"),
-				ConfigKeyLayers: []map[string]interface{}{
-					{
-						ConfigKeyLayerName: "land",
-						ConfigKeySQL:       "SELECT gid, ST_AsBinary(geom) FROM ne_10m_land_scale_rank WHERE geom && !BBOX!",
-					},
-				},
+				ConfigKeyLayerName: "land",
+				ConfigKeySQL:       "SELECT gid, ST_AsBinary(geom) FROM ne_10m_land_scale_rank WHERE geom && !BBOX!",
 			},
 			layerName: "land",
 			geom:      geom.MultiPolygon{},
 		},
 		"zoom token replacement": {
 			config: map[string]interface{}{
-				ConfigKeyHost:        os.Getenv("PGHOST"),
-				ConfigKeyPort:        port,
-				ConfigKeyDB:          os.Getenv("PGDATABASE"),
-				ConfigKeyUser:        os.Getenv("PGUSER"),
-				ConfigKeyPassword:    os.Getenv("PGPASSWORD"),
-				ConfigKeySSLMode:     os.Getenv("PGSSLMODE"),
-				ConfigKeySSLKey:      os.Getenv("PGSSLKEY"),
-				ConfigKeySSLCert:     os.Getenv("PGSSLCERT"),
-				ConfigKeySSLRootCert: os.Getenv("PGSSLROOTCERT"),
-				ConfigKeyLayers: []map[string]interface{}{
-					{
-						ConfigKeyLayerName: "land",
-						ConfigKeySQL:       "SELECT gid, ST_AsBinary(geom) FROM ne_10m_land_scale_rank WHERE gid = !ZOOM! AND geom && !BBOX!",
-					},
-				},
+				ConfigKeyLayerName: "land",
+				ConfigKeySQL:       "SELECT gid, ST_AsBinary(geom) FROM ne_10m_land_scale_rank WHERE gid = !ZOOM! AND geom && !BBOX!",
 			},
 			layerName: "land",
+			geom:      geom.MultiPolygon{},
+		},
+		"configured geometry_type": {
+			config: map[string]interface{}{
+				ConfigKeyLayerName: "land",
+				ConfigKeyGeomType:  "multipolygon",
+				ConfigKeySQL:       "SELECT gid, ST_AsBinary(geom) FROM invalid_table_to_check_query_table_was_not_inspected WHERE geom && !BBOX!",
+			},
+			layerName: "land",
+			geom:      geom.MultiPolygon{},
+		},
+		"configured geometry_type (case insensitive)": {
+			config: map[string]interface{}{
+				ConfigKeyLayerName: "land",
+				ConfigKeyGeomType:  "MultiPolyGOn",
+				ConfigKeySQL:       "SELECT gid, ST_AsBinary(geom) FROM invalid_table_to_check_query_table_was_not_inspected WHERE geom && !BBOX!",
+			},
+			layerName: "land",
+			geom:      geom.MultiPolygon{},
+		},
+		"invalid configured geometry_type": {
+			config: map[string]interface{}{
+				ConfigKeyLayerName: "land",
+				ConfigKeyGeomType:  "invalid",
+				ConfigKeySQL:       "SELECT gid, ST_AsBinary(geom) FROM invalid_table_to_check_query_table_was_not_inspected WHERE geom && !BBOX!",
+			},
+			layerName: "land",
+			err:       "unsupported geometry_type",
 			geom:      geom.MultiPolygon{},
 		},
 	}


### PR DESCRIPTION
addressed in #180 

This feature is important for more complex queries (joins or spatial operations) were a `LIMIT 1` still has to run against the whole table (because !BBOX! covers the whole planet).