### PR TITLE
Issue 383 - Id field as tag

### DIFF
--- a/provider/postgis/README.md
+++ b/provider/postgis/README.md
@@ -32,7 +32,7 @@ In addition to the connection configuration above, Provider Layers need to be co
 [[providers.layers]]
 name = "landuse"
 # this table uses "geom" for the geometry_fieldname and "gid" for the id_fieldname so they don't need to be configured
-tablename = "gis.zoning_base_3857"  
+tablename = "gis.zoning_base_3857"
 ```
 
 ### Provider Layers Properties
@@ -78,7 +78,7 @@ $ TEGOLA_SQL_DEBUG=LAYER_SQL tegola serve --config=/path/to/conf.toml
 ```
 
 ## Testing
-Testing is designed to work against a live PostGIS database. To run the PostGIS tests, the following environment variables need to be set:
+Testing is designed to work against a live PostGIS database. To see how to set up a database check this [ci script](https://github.com/go-spatial/tegola/blob/master/ci/config_postgis.sh). To run the PostGIS tests, the following environment variables need to be set:
 
 ```bash
 $ export RUN_POSTGIS_TESTS=yes

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -289,7 +289,7 @@ func NewTileProvider(config dict.Dicter) (provider.Tiler, error) {
 					return nil, fmt.Errorf("SQL for layer (%v) %v does not contain the geometry field: %v", i, lname, geomfld)
 				}
 				if !strings.Contains(sql, idfld) {
-					return nil, fmt.Errorf("SQL for layer (%v) %v does not contain the id field for the geometry: %v", i, lname, idfld)
+					return nil, fmt.Errorf("SQL for layer (%v) %v does not contain the id field for the geometry: %v", i, lname, sql)
 				}
 			}
 

--- a/provider/postgis/postgis_test.go
+++ b/provider/postgis/postgis_test.go
@@ -303,6 +303,17 @@ func TestTileFeatures(t *testing.T) {
 			expectedFeatureCount: 4032,
 			expectedTags:         []string{"scalerank"},
 		},
+		"tablename query with fields and id as field": {
+			layerConfig: map[string]interface{}{
+				postgis.ConfigKeyLayerName: "land",
+				postgis.ConfigKeyTablename: "ne_10m_land_scale_rank",
+				postgis.ConfigKeyGeomIDField: "gid",
+				postgis.ConfigKeyFields:    []string{"gid", "scalerank"},
+			},
+			tile:                 provider.NewTile(1, 1, 1, 64, proj.WebMercator),
+			expectedFeatureCount: 4032,
+			expectedTags:         []string{"gid", "scalerank"},
+		},
 		"SQL sub-query": {
 			layerConfig: map[string]interface{}{
 				postgis.ConfigKeyLayerName: "land",


### PR DESCRIPTION
should close #383 

The sql generator always adds a `gid` field, if config also includes the `gid` field as a tag, it is added twice. Meaning there could be two identical `gid` columns. The `decipherFields` function, also parses the first appearance of `gid` as usual but the second as a tag.