### PR TITLE
Fix "Server" heading spelling

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-# Sever
+# Server
 
 The server package is responsible for handling webserver requests for map tiles and various JSON endpoints describing the configured server. Example config:
 


### PR DESCRIPTION
This fixes the spelling of "Server" within the level 1 heading.

This will close issue #475.