### PR TITLE
provider/postgis - close connection pool

### DIFF
--- a/provider/gpkg/gpkg_register.go
+++ b/provider/gpkg/gpkg_register.go
@@ -397,7 +397,7 @@ var providers []Provider
 
 // Cleanup will close all database connections and destroy all previously instantiated Provider instances
 func Cleanup() {
-	log.Printf("cleaning up gpkg providers")
+	log.Infof("cleaning up gpkg providers")
 
 	for i := range providers {
 		if err := providers[i].Close(); err != nil {

--- a/provider/gpkg/gpkg_register.go
+++ b/provider/gpkg/gpkg_register.go
@@ -392,11 +392,13 @@ func NewTileProvider(config dict.Dicter) (provider.Tiler, error) {
 	return &p, err
 }
 
-// reference to all instantiated proivders
+// reference to all instantiated providers
 var providers []Provider
 
 // Cleanup will close all database connections and destroy all previously instantiated Provider instances
 func Cleanup() {
+	log.Printf("cleaning up gpkg providers")
+
 	for i := range providers {
 		if err := providers[i].Close(); err != nil {
 			log.Errorf("err closing connection: %v", err)

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -595,7 +595,7 @@ func (p *Provider) Close() {
 	p.pool.Close()
 }
 
-// reference to all instantiated proivders
+// reference to all instantiated providers
 var providers []Provider
 
 // Cleanup will close all database connections and destroy all previously instantiated Provider instances

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -74,7 +74,7 @@ const (
 )
 
 func init() {
-	provider.Register(Name, NewTileProvider, nil)
+	provider.Register(Name, NewTileProvider, Cleanup)
 }
 
 // isSelectQuery is a regexp to check if a query starts with `SELECT`,
@@ -319,6 +319,9 @@ func NewTileProvider(config dict.Dicter) (provider.Tiler, error) {
 		lyrs[lname] = l
 	}
 	p.layers = lyrs
+
+	// track the provider so we can clean it up later
+	providers = append(providers, p)
 
 	return p, nil
 }
@@ -585,4 +588,23 @@ func (p Provider) TileFeatures(ctx context.Context, layer string, tile provider.
 	}
 
 	return nil
+}
+
+// Close will close the Provider's database connectio
+func (p *Provider) Close() {
+	p.pool.Close()
+}
+
+// reference to all instantiated proivders
+var providers []Provider
+
+// Cleanup will close all database connections and destroy all previously instantiated Provider instances
+func Cleanup() {
+	log.Printf("cleaning up postgis providers")
+
+	for i := range providers {
+		providers[i].Close()
+	}
+
+	providers = make([]Provider, 0)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -75,7 +75,20 @@ func Start(a *atlas.Atlas, port string) *http.Server {
 
 	// start our server
 	srv := &http.Server{Addr: port, Handler: NewRouter(a)}
-	go func() { log.Error(srv.ListenAndServe()) }()
+	go func() {
+		if err := srv.ListenAndServe(); err != nil {
+			switch err {
+			case http.ErrServerClosed:
+				log.Info("http server closed")
+				return
+			default:
+				log.Fatal(err)
+				return
+			}
+		}
+		return
+	}()
+
 	return srv
 }
 


### PR DESCRIPTION
- added Cleanup routine to postgis to explicitly close the connection pool on shutdown.
- better error management for http server.ListenAndServe