### PR TITLE
gzip polish

### DIFF
--- a/cache/s3/s3.go
+++ b/cache/s3/s3.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-spatial/tegola"
 	"github.com/go-spatial/tegola/cache"
 	"github.com/go-spatial/tegola/dict"
+	"github.com/go-spatial/tegola/mvt"
 )
 
 var (
@@ -46,7 +47,7 @@ const (
 	DefaultRegion      = "us-east-1"
 	DefaultAccessKey   = ""
 	DefaultSecretKey   = ""
-	DefaultContentType = "application/vnd.mapbox-vector-tile"
+	DefaultContentType = mvt.MimeType
 	DefaultEndpoint    = ""
 )
 

--- a/cmd/tegola_lambda/README.md
+++ b/cmd/tegola_lambda/README.md
@@ -55,6 +55,7 @@ In order to access the Lambda function publicly and API gateway will need to be 
   - Use Default Timeout: Un-check and set to 29 seconds. This is currently the max that API gateway allows.
   - Click "Save". A dialog box with pop up asking to allow the API Gateway permission to the selected Lambda function. Click "OK".
 - On the left, under the APIs section, locate "Settings" under the configured API.
+  - Under "Content Encoding" check the box to enable and set the value to 0. This is important as tegola will return tiles in gzip encoded. Without this checked the content encoding will be improperly handled. 
   - Under "Binary Media Types" click "Add Binary Media Type".
   - Input `*/*` as the value. This is necessary as tegola returns protocol buffers, which are a binary format. Without this configuration API gateway will return the vector tile payloads as base64 encoded strings.
   - Click "Save Changes".

--- a/cmd/tegola_lambda/main.go
+++ b/cmd/tegola_lambda/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-spatial/tegola/cmd/internal/register"
 	"github.com/go-spatial/tegola/config"
 	"github.com/go-spatial/tegola/dict"
+	"github.com/go-spatial/tegola/mvt"
 	"github.com/go-spatial/tegola/server"
 )
 
@@ -93,11 +94,11 @@ func main() {
 	// http route setup
 	mux := server.NewRouter(nil)
 
-	// the second argument here tells algnhasa to watch for "application/x-protobuf" Content-Type headers
+	// the second argument here tells algnhasa to watch for the MVT MimeType Content-Type headers
 	// if it detects this in the response the payload will be base64 encoded. Lambda needs to be configured
 	// to handle binary responses so it can convert the base64 encoded payload back into binary prior
 	// to sending to the client
-	algnhsa.ListenAndServe(mux, []string{"application/x-protobuf"})
+	algnhsa.ListenAndServe(mux, []string{mvt.MimeType})
 }
 
 // URLRoot overrides the default server.URLRoot function in order to include the "stage" part of the root

--- a/server/handle_map_layer_zxy.go
+++ b/server/handle_map_layer_zxy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-spatial/tegola/atlas"
 	"github.com/go-spatial/tegola/internal/log"
 	"github.com/go-spatial/tegola/maths"
+	"github.com/go-spatial/tegola/mvt"
 )
 
 type HandleMapLayerZXY struct {
@@ -169,7 +170,8 @@ func (req HandleMapLayerZXY) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// mimetype for mapbox vector tiles
 	// https://www.iana.org/assignments/media-types/application/vnd.mapbox-vector-tile
-	w.Header().Add("Content-Type", "application/vnd.mapbox-vector-tile")
+	w.Header().Add("Content-Type", mvt.MimeType)
+	w.Header().Add("Content-Length", fmt.Sprintf("%d", len(pbyte)))
 	w.WriteHeader(http.StatusOK)
 	w.Write(pbyte)
 

--- a/server/middleware_gzip.go
+++ b/server/middleware_gzip.go
@@ -40,6 +40,7 @@ func GZipHandler(next http.Handler) http.Handler {
 
 		// set appropriate header
 		w.Header().Set("Content-Encoding", "gzip")
+
 		next.ServeHTTP(w, r)
 		return
 	})
@@ -53,6 +54,9 @@ type gzipDecompressResponseWriter struct {
 }
 
 func (w *gzipDecompressResponseWriter) Header() http.Header {
+	// delete the Content-Length header as it would give the length of the compressed tile
+	// rather than the uncompressed tile
+	w.resp.Header().Del("Content-Length")
 	return w.resp.Header()
 }
 
@@ -78,6 +82,7 @@ func (w *gzipDecompressResponseWriter) Write(b []byte) (int, error) {
 	return w.resp.Write(buf.Bytes())
 }
 
+// TODO (arolek): adjust Content-Length header on decompress
 func (w *gzipDecompressResponseWriter) WriteHeader(i int) {
 	w.status = i
 	w.resp.WriteHeader(i)

--- a/server/middleware_tile_cache.go
+++ b/server/middleware_tile_cache.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -70,11 +71,12 @@ func TileCacheHandler(a *atlas.Atlas, next http.Handler) http.Handler {
 		//	cors header
 		w.Header().Set("Access-Control-Allow-Origin", CORSAllowedOrigin)
 
-		// mimetype for protocol buffers
-		w.Header().Add("Content-Type", "application/x-protobuf")
+		// mimetype for mapbox vector tiles
+		w.Header().Add("Content-Type", mvt.MimeType)
 
 		// communicate the cache is being used
 		w.Header().Add("Tegola-Cache", "HIT")
+		w.Header().Add("Content-Length", fmt.Sprintf("%d", len(pbyte)))
 
 		w.Write(cachedTile)
 		return


### PR DESCRIPTION
- added Content-Length header support for gzipped tiles
- remove Content-Length header on gzip decompress
- moved MVT MimeType to a const in the mvt package
- updated lambda instructions