### PR TITLE
don't require IDs for mvt features. closes #338

### DIFF
--- a/mvt/cleanline_internal_test.go
+++ b/mvt/cleanline_internal_test.go
@@ -18,7 +18,7 @@ func TestCleanline(t *testing.T) {
 			el := cleanLine(tc.line)
 
 			if !tegola.IsLineStringEqual(el, tc.expected) {
-				t.Errorf("expected %v, Got %v", tc.line.GoString(), el.GoString())
+				t.Errorf("expected %v, got %v", tc.line.GoString(), el.GoString())
 			}
 		}
 	}

--- a/mvt/cleanline_internal_test.go
+++ b/mvt/cleanline_internal_test.go
@@ -3,18 +3,28 @@ package mvt
 import (
 	"testing"
 
-	"github.com/gdey/tbltest"
 	"github.com/go-spatial/tegola"
 	"github.com/go-spatial/tegola/basic"
 )
 
 func TestCleanline(t *testing.T) {
-	type testcase struct {
+	type tcase struct {
 		line     basic.Line
 		expected basic.Line
 	}
-	tests := tbltest.Cases(
-		testcase{
+
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			el := cleanLine(tc.line)
+
+			if !tegola.IsLineStringEqual(el, tc.expected) {
+				t.Errorf("expected %v, Got %v", tc.line.GoString(), el.GoString())
+			}
+		}
+	}
+
+	tests := map[string]tcase{
+		"1": tcase{
 			line: basic.Line{ // basic.Line len(000007) direction(clockwise).
 				{2046.000000, 1386.000000}, {2047.000000, 1386.000000}, {2047.000000, 1387.000000}, {2046.000000, 1387.000000}, {2046.000000, 1386.000000}, {2046.000000, 1387.000000}, {2046.000000, 1386.000000}, // 000000 — 000006
 			},
@@ -22,7 +32,7 @@ func TestCleanline(t *testing.T) {
 				{2047.000000, 1386.000000}, {2047.000000, 1387.000000}, {2046.000000, 1387.000000}, {2046.000000, 1386.000000},
 			},
 		},
-		testcase{
+		"2": tcase{
 			basic.Line{ // basic.Line len(000005) direction(counter clockwise).
 				{3650.000000, 1342.000000}, {3651.000000, 1343.000000}, {3651.000000, 1342.000000}, {3651.000000, 1341.000000}, {3651.000000, 1342.000000}, // 000000 — 000004
 			},
@@ -30,7 +40,7 @@ func TestCleanline(t *testing.T) {
 				{3650.000000, 1342.000000}, {3651.000000, 1343.000000}, {3651.000000, 1342.000000},
 			},
 		},
-		testcase{
+		"3": tcase{
 			basic.Line{ // basic.Line len(000010) direction(counter clockwise).
 				{3650.000000, 1342.000000}, {3651.000000, 1343.000000}, {3652.000000, 1343.000000}, {3651.000000, 1343.000000}, {3651.000000, 1342.000000}, {3651.000000, 1341.000000}, {3651.000000, 1342.000000}, {3651.000000, 1341.000000}, {3651.000000, 1342.000000}, {3650.000000, 1342.000000}, // 000000 — 000009
 			},
@@ -38,12 +48,9 @@ func TestCleanline(t *testing.T) {
 				{3650.000000, 1342.000000}, {3651.000000, 1343.000000}, {3651.000000, 1342.000000},
 			},
 		},
-	)
-	tests.Run(func(idx int, test testcase) {
-		el := cleanLine(test.line)
-		if !tegola.IsLineStringEqual(el, test.expected) {
-			t.Errorf("Test %v: Did not get expected line. Got %v", idx, el.GoString())
-		}
-	})
+	}
 
+	for name, tc := range tests {
+		t.Run(name, fn(tc))
+	}
 }

--- a/mvt/feature_internal_test.go
+++ b/mvt/feature_internal_test.go
@@ -1,31 +1,30 @@
 package mvt
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
 
-	"context"
-
-	"github.com/gdey/tbltest"
 	"github.com/go-spatial/tegola"
 	"github.com/go-spatial/tegola/basic"
 	"github.com/go-spatial/tegola/mvt/vector_tile"
 )
 
 func TestScaleLinestring(t *testing.T) {
-
 	tile := tegola.NewTile(20, 0, 0)
 	cursor := NewCursor(tile)
+
 	newLine := func(ptpairs ...float64) (ln basic.Line) {
 		for i, j := 0, 1; j < len(ptpairs); i, j = i+2, j+2 {
 			pt, err := tile.FromPixel(tegola.WebMercator, [2]float64{ptpairs[i], ptpairs[j]})
 			if err != nil {
 				panic(fmt.Sprintf("error trying to convert %v,%v to WebMercator. %v", ptpairs[i], ptpairs[j], err))
 			}
-			ln = append(ln, basic.Point(pt))
 
+			ln = append(ln, basic.Point(pt))
 		}
+
 		return ln
 	}
 
@@ -33,12 +32,17 @@ func TestScaleLinestring(t *testing.T) {
 		g tegola.LineString
 		e basic.Line
 	}
-	fn := func(t *testing.T, tc tcase) {
-		got := cursor.scalelinestr(tc.g)
-		if !reflect.DeepEqual(tc.e, got) {
-			t.Errorf("scale line, expected %v got %v", tc.e, got)
+
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			got := cursor.scalelinestr(tc.g)
+
+			if !reflect.DeepEqual(tc.e, got) {
+				t.Errorf("expected %v got %v", tc.e, got)
+			}
 		}
 	}
+
 	tests := map[string]tcase{
 		"duplicate pt simple line": {
 			g: basic.NewLine(9.0, 9.0, 9.0, 9.0),
@@ -52,20 +56,21 @@ func TestScaleLinestring(t *testing.T) {
 			e: basic.NewLine(9.0, 9.0, 11.0, 9.0, 11.0, 14.0),
 		},
 	}
+
 	for name, tc := range tests {
-		tc := tc
-		t.Run(name, func(t *testing.T) { fn(t, tc) })
+		t.Run(name, fn(tc))
 	}
 }
 
 func TestEncodeGeometry(t *testing.T) {
-	type tc struct {
-		desc string `tbltest:"desc"`
+	type tcase struct {
+		desc string
 		geo  basic.Geometry
 		typ  vectorTile.Tile_GeomType
 		egeo []uint32
 		eerr error
 	}
+
 	tile := tegola.NewTile(20, 0, 0)
 	fromPixel := func(x, y float64) *basic.Point {
 		pt, err := tile.FromPixel(tegola.WebMercator, [2]float64{x, y})
@@ -75,50 +80,54 @@ func TestEncodeGeometry(t *testing.T) {
 		bpt := basic.Point(pt)
 		return &bpt
 	}
-	fn := func(i int, tcase tc) {
-		g, gtype, err := encodeGeometry(context.Background(), tcase.geo, tile, true)
-		if tcase.eerr != err {
-			t.Errorf("[%v] error, Expected %v Got %v", i, tcase.eerr, err)
-		}
-		if gtype != tcase.typ {
-			t.Errorf("[%v] geometry type, Expected %v Got %v", i, tcase.typ, gtype)
-		}
-		if len(g) != len(tcase.egeo) {
-			t.Errorf("[%v] geometry length, Expected %v Got %v ", i, len(tcase.egeo), len(g))
-			t.Logf("[%v] Geometries, Expected %v Got %v", i, tcase.egeo, g)
-		}
-		for j := range tcase.egeo {
 
-			if j < len(g) && tcase.egeo[j] != g[j] {
-				t.Errorf("[%v] Geometry at %v, Expected %v Got %v", i, j, tcase.egeo[j], g[j])
-				t.Logf("[%v] Geometry, Expected %v Got %v", i, tcase.egeo, g)
-				break
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			g, gtype, err := encodeGeometry(context.Background(), tc.geo, tile, true)
+			if tc.eerr != err {
+				t.Errorf("error, Expected %v Got %v", tc.eerr, err)
+			}
+			if gtype != tc.typ {
+				t.Errorf("geometry type, Expected %v Got %v", tc.typ, gtype)
+			}
+			if len(g) != len(tc.egeo) {
+				t.Errorf("geometry length, Expected %v Got %v ", len(tc.egeo), len(g))
+				t.Logf("Geometries, Expected %v Got %v", tc.egeo, g)
+			}
+			for j := range tc.egeo {
+
+				if j < len(g) && tc.egeo[j] != g[j] {
+					t.Errorf("Geometry at %v, Expected %v Got %v", j, tc.egeo[j], g[j])
+					t.Logf("Geometry, Expected %v Got %v", tc.egeo, g)
+					break
+				}
 			}
 		}
 	}
-	tbltest.Cases(
-		tc{ //0
+
+	tests := map[string]tcase{
+		"0": tcase{
 			geo:  nil,
 			typ:  vectorTile.Tile_UNKNOWN,
 			egeo: []uint32{},
 			eerr: ErrNilGeometryType,
 		},
-		tc{ // 1
+		"1": tcase{
 			geo:  fromPixel(1, 1),
 			typ:  vectorTile.Tile_POINT,
 			egeo: []uint32{9, 2, 2},
 		},
-		tc{ // 2
+		"2": tcase{
 			geo:  fromPixel(25, 16),
 			typ:  vectorTile.Tile_POINT,
 			egeo: []uint32{9, 50, 32},
 		},
-		tc{ // 3
+		"3": tcase{
 			geo:  basic.MultiPoint{*fromPixel(5, 7), *fromPixel(3, 2)},
 			typ:  vectorTile.Tile_POINT,
 			egeo: []uint32{17, 10, 14, 3, 11},
 		},
-		tc{ // 4
+		"4": tcase{
 			geo:  basic.Line{*fromPixel(2, 2), *fromPixel(2, 10), *fromPixel(10, 10)},
 			typ:  vectorTile.Tile_LINESTRING,
 			egeo: []uint32{9, 2, 2, 18, 0, 16, 16, 0},
@@ -126,7 +135,7 @@ func TestEncodeGeometry(t *testing.T) {
 		/*
 				Disabling this for now; Currently it's getting clipped out because the transformation. scaling and clipping are intermingled with the encoding
 				process. Once that is separated out we can have a better encoding test. Issue #224
-			tc{ // 5
+			"5":tcase{ // 5
 				geo: basic.MultiLine{
 					basic.Line{*fromPixel(2, 2), *fromPixel(2, 10), *fromPixel(10, 10)},
 					basic.Line{*fromPixel(1, 1), *fromPixel(3, 5)},
@@ -134,19 +143,19 @@ func TestEncodeGeometry(t *testing.T) {
 				typ:  vectorTile.Tile_LINESTRING,
 				egeo: []uint32{9, 2, 2, 18, 0, 16, 16, 0, 9, 15, 15, 10, 4, 8},
 			},
-				tc{ // 6
-					geo: basic.Polygon{
-						basic.Line{
-							*fromPixel(3, 6),
-							*fromPixel(8, 12),
-							*fromPixel(20, 34),
-						},
+			"6":tcase{ // 6
+				geo: basic.Polygon{
+					basic.Line{
+						*fromPixel(3, 6),
+						*fromPixel(8, 12),
+						*fromPixel(20, 34),
 					},
-					typ: vectorTile.Tile_POLYGON,
-					egeo: []uint32{9, 6, 12, 26, 10, 12, 24, 44, 23, 39, 15},
 				},
+				typ: vectorTile.Tile_POLYGON,
+				egeo: []uint32{9, 6, 12, 26, 10, 12, 24, 44, 23, 39, 15},
+			},
 		*/
-		tc{ // 7
+		"7": tcase{
 			geo: basic.MultiPolygon{
 				basic.Polygon{ // basic.Polygon len(000002).
 					basic.Line{ // basic.Line len(000004) direction(clockwise) line(00).
@@ -174,31 +183,9 @@ func TestEncodeGeometry(t *testing.T) {
 			typ:  vectorTile.Tile_POLYGON,
 			egeo: []uint32{9, 0, 0, 26, 18, 0, 0, 18, 17, 0, 15, 9, 22, 4, 26, 18, 0, 0, 18, 17, 0, 15, 9, 2, 15, 26, 0, 8, 8, 0, 0, 7, 15},
 		},
-	).Run(fn)
-}
-
-func TestNewFeature(t *testing.T) {
-	testcases := []struct {
-		geo      tegola.Geometry
-		tags     map[string]interface{}
-		expected []Feature
-	}{
-		{
-			geo:      nil,
-			tags:     nil,
-			expected: []Feature{},
-		},
 	}
-	for i, tcase := range testcases {
-		got := NewFeatures(tcase.geo, tcase.tags)
-		if len(tcase.expected) != len(got) {
-			t.Errorf("Test %v: Expected to get %v features got %v features.", i, len(tcase.expected), len(got))
-			continue
-		}
-		if len(tcase.expected) <= 0 {
-			continue
-		}
-		// TODO test to make sure we got the correct feature
 
+	for name, tc := range tests {
+		t.Run(name, fn(tc))
 	}
 }

--- a/mvt/feature_internal_test.go
+++ b/mvt/feature_internal_test.go
@@ -85,20 +85,20 @@ func TestEncodeGeometry(t *testing.T) {
 		return func(t *testing.T) {
 			g, gtype, err := encodeGeometry(context.Background(), tc.geo, tile, true)
 			if tc.eerr != err {
-				t.Errorf("error, Expected %v Got %v", tc.eerr, err)
+				t.Errorf("error, expected %v got %v", tc.eerr, err)
 			}
 			if gtype != tc.typ {
-				t.Errorf("geometry type, Expected %v Got %v", tc.typ, gtype)
+				t.Errorf("geometry type, expected %v got %v", tc.typ, gtype)
 			}
 			if len(g) != len(tc.egeo) {
-				t.Errorf("geometry length, Expected %v Got %v ", len(tc.egeo), len(g))
-				t.Logf("Geometries, Expected %v Got %v", tc.egeo, g)
+				t.Errorf("geometry length, expected %v got %v ", len(tc.egeo), len(g))
+				t.Logf("geometries, expected %v got %v", tc.egeo, g)
 			}
 			for j := range tc.egeo {
 
 				if j < len(g) && tc.egeo[j] != g[j] {
-					t.Errorf("Geometry at %v, Expected %v Got %v", j, tc.egeo[j], g[j])
-					t.Logf("Geometry, Expected %v Got %v", tc.egeo, g)
+					t.Errorf("geometry at %v, expected %v got %v", j, tc.egeo[j], g[j])
+					t.Logf("geometry, expected %v got %v", tc.egeo, g)
 					break
 				}
 			}

--- a/mvt/fuzz.go
+++ b/mvt/fuzz.go
@@ -1,6 +1,0 @@
-package mvt
-
-func Fuzz(data []byte) int {
-
-	return 0
-}

--- a/mvt/layer.go
+++ b/mvt/layer.go
@@ -146,9 +146,9 @@ func (l *Layer) AddFeatures(features ...Feature) {
 	b := make([]Feature, len(l.features), len(l.features)+len(features))
 
 	copy(b, l.features)
+	copy(b[len(l.features):], features)
 
 	l.features = b
-	l.features = append(l.features, features...)
 }
 
 // RemoveFeature allows you to remove one or more features, with the provided indexes.

--- a/mvt/layer.go
+++ b/mvt/layer.go
@@ -139,38 +139,20 @@ func (l *Layer) Features() (f []Feature) {
 	return f
 }
 
-//AddFeatures will add one or more Features to the Layer, if a features ID is a the same as
-//Any already in the Layer, it will ignore those features.
-//If the id fields is nil, the feature will always be added.
-func (l *Layer) AddFeatures(features ...Feature) (skipped bool) {
-
+// AddFeatures will add one or more Features to the Layer
+// per the spec features SHOULD have unique ids but it's not required
+func (l *Layer) AddFeatures(features ...Feature) {
+	// pre allocate memory
 	b := make([]Feature, len(l.features), len(l.features)+len(features))
+
 	copy(b, l.features)
+
 	l.features = b
-FEATURES_LOOP:
-	for _, f := range features {
-		if f.ID == nil {
-			l.features = append(l.features, f)
-			continue
-		}
-		for _, cf := range l.features {
-			if cf.ID == nil {
-				continue
-			}
-			// We matched, we skip
-			if *cf.ID == *f.ID {
-				skipped = true
-				continue FEATURES_LOOP
-			}
-		}
-		// There were no matches, let's add it to our list.
-		l.features = append(l.features, f)
-	}
-	return skipped
+	l.features = append(features)
 }
 
-//RemoveFeature allows you to remove one or more features, with the provided indexes.
-//To figure out the indexes, use the indexs from the Features array.
+// RemoveFeature allows you to remove one or more features, with the provided indexes.
+// To figure out the indexes, use the indexs from the Features array.
 func (l *Layer) RemoveFeature(idxs ...int) {
 	var features = make([]Feature, 0, len(l.features))
 SKIP:

--- a/mvt/layer.go
+++ b/mvt/layer.go
@@ -143,7 +143,7 @@ func (l *Layer) Features() (f []Feature) {
 // per the spec features SHOULD have unique ids but it's not required
 func (l *Layer) AddFeatures(features ...Feature) {
 	// pre allocate memory
-	b := make([]Feature, len(l.features), len(l.features)+len(features))
+	b := make([]Feature, len(l.features)+len(features))
 
 	copy(b, l.features)
 	copy(b[len(l.features):], features)

--- a/mvt/layer.go
+++ b/mvt/layer.go
@@ -148,7 +148,7 @@ func (l *Layer) AddFeatures(features ...Feature) {
 	copy(b, l.features)
 
 	l.features = b
-	l.features = append(features)
+	l.features = append(l.features, features...)
 }
 
 // RemoveFeature allows you to remove one or more features, with the provided indexes.

--- a/mvt/layer_internal_test.go
+++ b/mvt/layer_internal_test.go
@@ -46,11 +46,11 @@ func TestLayer(t *testing.T) {
 		return func(t *testing.T) {
 			vt, err := tc.layer.VTileLayer(context.Background(), tile)
 			if err != tc.eerr {
-				t.Errorf("unexpected error, Expected %v Got %v", tc.eerr, err)
+				t.Errorf("unexpected error, expected %v got %v", tc.eerr, err)
 			}
 			if tc.vtlayer == nil {
 				if vt != nil {
-					t.Errorf("expected nil value, Got non-nil")
+					t.Errorf("expected nil value, got non-nil")
 				}
 				return
 			}
@@ -59,21 +59,21 @@ func TestLayer(t *testing.T) {
 				return
 			}
 			if *tc.vtlayer.Version != *vt.Version {
-				t.Errorf("versions do not match, Expected %v Got %v", *tc.vtlayer.Version, *vt.Version)
+				t.Errorf("versions do not match, expected %v got %v", *tc.vtlayer.Version, *vt.Version)
 			}
 			if *tc.vtlayer.Name != *vt.Name {
-				t.Errorf("names do not match, Expected %v Got %v", *tc.vtlayer.Name, *vt.Name)
+				t.Errorf("names do not match, expected %v got %v", *tc.vtlayer.Name, *vt.Name)
 			}
 			if *tc.vtlayer.Extent != *vt.Extent {
-				t.Errorf("extent do not match, Expected %v Got %v", *tc.vtlayer.Extent, *vt.Extent)
+				t.Errorf("extent do not match, expected %v got %v", *tc.vtlayer.Extent, *vt.Extent)
 			}
 			if len(tc.vtlayer.Features) != len(vt.Features) {
-				t.Errorf("features do not have the same length, Expected %v Got %v", len(tc.vtlayer.Features), len(vt.Features))
+				t.Errorf("features do not have the same length, expected %v got %v", len(tc.vtlayer.Features), len(vt.Features))
 			}
 
 			// TODO: Should check to see if the features are equal.
 			if len(tc.vtlayer.Values) != len(vt.Values) {
-				t.Errorf("values do not have the same length, Expected %v Got %v", len(tc.vtlayer.Values), len(vt.Values))
+				t.Errorf("values do not have the same length, expected %v got %v", len(tc.vtlayer.Values), len(vt.Values))
 			}
 
 			// TODO: Should check that the Values are equal.

--- a/mvt/layer_internal_test.go
+++ b/mvt/layer_internal_test.go
@@ -1,0 +1,142 @@
+package mvt
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-spatial/tegola"
+	"github.com/go-spatial/tegola/basic"
+	"github.com/go-spatial/tegola/internal/p"
+	"github.com/go-spatial/tegola/mvt/vector_tile"
+)
+
+func newTileLayer(name string, keys []string, values []*vectorTile.Tile_Value, features []*vectorTile.Tile_Feature) *vectorTile.Tile_Layer {
+	return &vectorTile.Tile_Layer{
+		Version:  p.Uint32(Version),
+		Name:     &name,
+		Features: features,
+		Keys:     keys,
+		Values:   values,
+		Extent:   p.Uint32(DefaultExtent),
+	}
+}
+
+func TestLayer(t *testing.T) {
+	tile := tegola.NewTile(0, 0, 0)
+
+	// TODO: gdey — think of a better way to build out features for a layer.
+	fromPixel := func(x, y float64) *basic.Point {
+		pt, err := tile.FromPixel(tegola.WebMercator, [2]float64{x, y})
+		if err != nil {
+			panic(fmt.Sprintf("error trying to convert %v,%v to WebMercator. %v", x, y, err))
+		}
+
+		bpt := basic.Point(pt)
+		return &bpt
+	}
+
+	type tcase struct {
+		layer   *Layer
+		vtlayer *vectorTile.Tile_Layer
+		eerr    error
+	}
+
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			vt, err := tc.layer.VTileLayer(context.Background(), tile)
+			if err != tc.eerr {
+				t.Errorf("unexpected error, Expected %v Got %v", tc.eerr, err)
+			}
+			if tc.vtlayer == nil {
+				if vt != nil {
+					t.Errorf("expected nil value, Got non-nil")
+				}
+				return
+			}
+			if vt == nil {
+				t.Errorf("for a Vector Tile, Expected non-nil Got nil")
+				return
+			}
+			if *tc.vtlayer.Version != *vt.Version {
+				t.Errorf("versions do not match, Expected %v Got %v", *tc.vtlayer.Version, *vt.Version)
+			}
+			if *tc.vtlayer.Name != *vt.Name {
+				t.Errorf("names do not match, Expected %v Got %v", *tc.vtlayer.Name, *vt.Name)
+			}
+			if *tc.vtlayer.Extent != *vt.Extent {
+				t.Errorf("extent do not match, Expected %v Got %v", *tc.vtlayer.Extent, *vt.Extent)
+			}
+			if len(tc.vtlayer.Features) != len(vt.Features) {
+				t.Errorf("features do not have the same length, Expected %v Got %v", len(tc.vtlayer.Features), len(vt.Features))
+			}
+
+			// TODO: Should check to see if the features are equal.
+			if len(tc.vtlayer.Values) != len(vt.Values) {
+				t.Errorf("values do not have the same length, Expected %v Got %v", len(tc.vtlayer.Values), len(vt.Values))
+			}
+
+			// TODO: Should check that the Values are equal.
+		}
+	}
+
+	tests := map[string]tcase{
+		"1": tcase{
+			layer: &Layer{
+				Name: "nofeatures",
+			},
+			vtlayer: newTileLayer("nofeatures", nil, nil, nil),
+		},
+		"2": tcase{
+			layer: &Layer{
+				Name: "onefeature",
+				features: []Feature{
+					{
+						Geometry: fromPixel(1, 1),
+						Tags: map[string]interface{}{
+							"tag1": "tag",
+							"tag2": "tag",
+						},
+					},
+				},
+			},
+			// features should not be nil, when we start comparing features this will fail.
+			// But for now it's okay.
+			vtlayer: newTileLayer("onefeature", []string{"tag1", "tag2"}, []*vectorTile.Tile_Value{vectorTileValue("tag")}, []*vectorTile.Tile_Feature{nil}),
+		},
+		"3": tcase{
+			layer: &Layer{
+				Name: "twofeature",
+				features: []Feature{
+					{
+						Geometry: &basic.Polygon{
+							basic.Line{
+								*fromPixel(3, 6),
+								*fromPixel(8, 12),
+								*fromPixel(20, 34),
+							},
+						},
+						Tags: map[string]interface{}{
+							"tag1": "tag",
+							"tag2": "tag",
+						},
+					},
+					{
+						Geometry: fromPixel(1, 1),
+						Tags: map[string]interface{}{
+							"tag1": "tag",
+							"tag2": "tag",
+						},
+					},
+				},
+			},
+			// features should not be nil, when we start comparing features this will fail.
+			// But for now it's okay.
+			vtlayer: newTileLayer("twofeature", []string{"tag1", "tag2"}, []*vectorTile.Tile_Value{vectorTileValue("tag1")}, []*vectorTile.Tile_Feature{nil, nil}),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, fn(tc))
+	}
+}

--- a/mvt/layer_test.go
+++ b/mvt/layer_test.go
@@ -1,84 +1,81 @@
-package mvt
+package mvt_test
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
-	"context"
-
-	"github.com/gdey/tbltest"
-	"github.com/go-spatial/tegola"
 	"github.com/go-spatial/tegola/basic"
+	"github.com/go-spatial/tegola/internal/p"
+	"github.com/go-spatial/tegola/mvt"
 	"github.com/go-spatial/tegola/mvt/vector_tile"
 )
 
 func newTileLayer(name string, keys []string, values []*vectorTile.Tile_Value, features []*vectorTile.Tile_Feature) *vectorTile.Tile_Layer {
-	version := uint32(2)
-	extent := uint32(4096)
 	return &vectorTile.Tile_Layer{
-		Version:  &version,
+		Version:  p.Uint32(mvt.Version),
 		Name:     &name,
 		Features: features,
 		Keys:     keys,
 		Values:   values,
-		Extent:   &extent,
+		Extent:   p.Uint32(mvt.DefaultExtent),
 	}
 }
 
 func TestLayerAddFeatures(t *testing.T) {
-	type tc struct {
-		features []Feature
-		expected []Feature // Nil means that it's the same as the features.
-		skipped  bool
+	type tcase struct {
+		features []mvt.Feature
+		expected []mvt.Feature // nil means that it's the same as the features.
 	}
-	fn := func(idx int, tcase tc) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("[%v] did not expect AddFeatures to panic: recovered: %v", idx, r)
+
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("did not expect AddFeatures to panic: recovered: %v", r)
+				}
+			}()
+
+			// creat a new layer to add features to
+			l := new(mvt.Layer)
+			l.AddFeatures(tc.features...)
+
+			gotFeatures := l.Features()
+
+			expectedFeatures := tc.expected
+			if expectedFeatures == nil {
+				expectedFeatures = tc.features
 			}
-		}()
-		// First create a blank layer to add the features to.
-		l := new(Layer)
-		skipped := l.AddFeatures(tcase.features...)
-		if tcase.skipped != skipped {
-			t.Errorf("[%v] skipped value; expected: %v got: %v", idx, tcase.skipped, skipped)
-		}
-		gotFeatures := l.Features()
-		expectedFeatures := tcase.expected
-		if expectedFeatures == nil {
-			expectedFeatures = tcase.features
-		}
-		if len(gotFeatures) != len(expectedFeatures) {
-			t.Errorf("[%v] number of features incorrect. expected: %v got: %v", idx, len(expectedFeatures), len(gotFeatures))
-		}
-		for i := range expectedFeatures {
-			if !reflect.DeepEqual(expectedFeatures[i], gotFeatures[i]) {
-				t.Errorf("[%v] expected feature %v to match. expected: %v got: %v", idx, i, expectedFeatures[i], gotFeatures[i])
+
+			if len(gotFeatures) != len(expectedFeatures) {
+				t.Errorf("number of features incorrect. expected: %v got: %v", len(expectedFeatures), len(gotFeatures))
+			}
+
+			for i := range expectedFeatures {
+				if !reflect.DeepEqual(expectedFeatures[i], gotFeatures[i]) {
+					t.Errorf("expected feature %v to match. expected: %v got: %v", i, expectedFeatures[i], gotFeatures[i])
+				}
 			}
 		}
 	}
-	newID := func(id uint64) *uint64 { return &id }
-	tbltest.Cases(
-		// nil id test 1
-		tc{
-			features: []Feature{
+
+	tests := map[string]tcase{
+		"nil id test 1": tcase{
+			features: []mvt.Feature{
 				{
 					Tags:     map[string]interface{}{"btag": "tag"},
 					Geometry: basic.Point{12.0, 15.0},
 				},
 				{
-					ID:       newID(1),
+					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
 					Geometry: basic.Point{12.0, 15.0},
 				},
 			},
 		},
-		// nil id test 2
-		tc{
-			features: []Feature{
+		"nil id test 2": tcase{
+			features: []mvt.Feature{
 				{
-					ID:       newID(1),
+					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
 					Geometry: basic.Point{12.0, 15.0},
 				},
@@ -88,152 +85,49 @@ func TestLayerAddFeatures(t *testing.T) {
 				},
 			},
 		},
-		// same feature test
-		tc{
-			features: []Feature{
+		"same feature test": tcase{
+			features: []mvt.Feature{
 				{
-					ID:       newID(1),
+					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
 					Geometry: basic.Point{12.0, 15.0},
 				},
 				{
-					ID:       newID(1),
-					Tags:     map[string]interface{}{"atag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
-				},
-			},
-			expected: []Feature{
-				{
-					ID:       newID(1),
+					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
 					Geometry: basic.Point{12.0, 15.0},
 				},
 			},
-			skipped: true,
-		},
-		// different feature test
-		tc{
-			features: []Feature{
+			expected: []mvt.Feature{
 				{
-					ID:       newID(1),
+					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
 					Geometry: basic.Point{12.0, 15.0},
 				},
 				{
-					ID:       newID(2),
+					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
 					Geometry: basic.Point{12.0, 15.0},
 				},
 			},
 		},
-	).Run(fn)
-}
-
-func TestLayer(t *testing.T) {
-	tile := tegola.NewTile(0, 0, 0)
-
-	//TODO: gdey — thing of a better way to build out features for a layer.
-	fromPixel := func(x, y float64) *basic.Point {
-		pt, err := tile.FromPixel(tegola.WebMercator, [2]float64{x, y})
-		if err != nil {
-			panic(fmt.Sprintf("error trying to convert %v,%v to WebMercator. %v", x, y, err))
-		}
-		bpt := basic.Point(pt)
-		return &bpt
-	}
-	type tc struct {
-		layer   *Layer
-		vtlayer *vectorTile.Tile_Layer
-		eerr    error
-	}
-	fn := func(i int, tcase tc) {
-		vt, err := tcase.layer.VTileLayer(context.Background(), tile)
-		if err != tcase.eerr {
-			t.Errorf("[%v] unexpected error, Expected %v Got %v", i, tcase.eerr, err)
-		}
-		if tcase.vtlayer == nil {
-			if vt != nil {
-				t.Errorf("[%v] for VTileLayer, Expected nil value Got non-nil", i)
-			}
-			return
-		}
-		if vt == nil {
-			t.Errorf("[%v] for a Vector Tile, Expected non-nil Got nil", i)
-			return
-		}
-		if *tcase.vtlayer.Version != *vt.Version {
-			t.Errorf("[%v] versions do not match, Expected %v Got %v", i, *tcase.vtlayer.Version, *vt.Version)
-		}
-		if *tcase.vtlayer.Name != *vt.Name {
-			t.Errorf("[%v] names do not match, Expected %v Got %v", i, *tcase.vtlayer.Name, *vt.Name)
-		}
-		if *tcase.vtlayer.Extent != *vt.Extent {
-			t.Errorf("[%v] extent do not match, Expected %v Got %v", i, *tcase.vtlayer.Extent, *vt.Extent)
-		}
-		if len(tcase.vtlayer.Features) != len(vt.Features) {
-			t.Errorf("[%v] features do not have the same length, Expected %v Got %v", i, len(tcase.vtlayer.Features), len(vt.Features))
-		}
-		// TODO: Should check to see if the features are equal.
-		if len(tcase.vtlayer.Values) != len(vt.Values) {
-			t.Errorf("[%v] values do not have the same length, Expected %v Got %v", i, len(tcase.vtlayer.Values), len(vt.Values))
-		}
-		// TODO: Should check that the Values are equal.
-
+		"different feature test": tcase{
+			features: []mvt.Feature{
+				{
+					ID:       p.Uint64(1),
+					Tags:     map[string]interface{}{"atag": "tag"},
+					Geometry: basic.Point{12.0, 15.0},
+				},
+				{
+					ID:       p.Uint64(2),
+					Tags:     map[string]interface{}{"atag": "tag"},
+					Geometry: basic.Point{12.0, 15.0},
+				},
+			},
+		},
 	}
 
-	tbltest.Cases(
-		tc{
-			layer: &Layer{
-				Name: "nofeatures",
-			},
-			vtlayer: newTileLayer("nofeatures", nil, nil, nil),
-		},
-		tc{
-			layer: &Layer{
-				Name: "onefeature",
-				features: []Feature{
-					{
-						Geometry: fromPixel(1, 1),
-						Tags: map[string]interface{}{
-							"tag1": "tag",
-							"tag2": "tag",
-						},
-					},
-				},
-			},
-			// features should not be nil, when we start comparing features this will fail.
-			// But for now it's okay.
-			vtlayer: newTileLayer("onefeature", []string{"tag1", "tag2"}, []*vectorTile.Tile_Value{vectorTileValue("tag")}, []*vectorTile.Tile_Feature{nil}),
-		},
-		tc{
-			layer: &Layer{
-				Name: "twofeature",
-				features: []Feature{
-					{
-						Geometry: &basic.Polygon{
-							basic.Line{
-								*fromPixel(3, 6),
-								*fromPixel(8, 12),
-								*fromPixel(20, 34),
-							},
-						},
-						Tags: map[string]interface{}{
-							"tag1": "tag",
-							"tag2": "tag",
-						},
-					},
-					{
-						Geometry: fromPixel(1, 1),
-						Tags: map[string]interface{}{
-							"tag1": "tag",
-							"tag2": "tag",
-						},
-					},
-				},
-			},
-			// features should not be nil, when we start comparing features this will fail.
-			// But for now it's okay.
-			vtlayer: newTileLayer("twofeature", []string{"tag1", "tag2"}, []*vectorTile.Tile_Value{vectorTileValue("tag1")}, []*vectorTile.Tile_Feature{nil, nil}),
-		},
-	).Run(fn)
+	for name, tc := range tests {
+		t.Run(name, fn(tc))
+	}
 }

--- a/mvt/mvt.go
+++ b/mvt/mvt.go
@@ -1,0 +1,6 @@
+package mvt
+
+const (
+	Version       = 2
+	DefaultExtent = 4096
+)

--- a/mvt/tile.go
+++ b/mvt/tile.go
@@ -57,9 +57,3 @@ func (t *Tile) VTile(ctx context.Context, tile *tegola.Tile) (vt *vectorTile.Til
 	}
 	return vt, nil
 }
-
-//TODO: What is this functions suppose to do?
-//TileFromVTile will return a Tile object from the given vectorTile Tile object
-func TileFromVTile(t *vectorTile.Tile) (*Tile, error) {
-	return nil, nil
-}

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -224,7 +224,7 @@ func NewTileProvider(config dict.Dicter) (provider.Tiler, error) {
 			return nil, fmt.Errorf("for layer (%v) %v : %v", i, lname, err)
 		}
 
-		idfld := "gid"
+		idfld := ""
 		idfld, err = layer.String(ConfigKeyGeomIDField, &idfld)
 		if err != nil {
 			return nil, fmt.Errorf("for layer (%v) %v : %v", i, lname, err)

--- a/provider/postgis/util.go
+++ b/provider/postgis/util.go
@@ -60,6 +60,7 @@ func genSQL(l *Layer, pool *pgx.ConnPool, tblname string, flds []string) (sql st
 		if f == `"`+l.geomField+`"` {
 			fgeom = i
 		}
+
 		if f == `"`+l.idField+`"` {
 			fgid = true
 		}
@@ -73,7 +74,7 @@ func genSQL(l *Layer, pool *pgx.ConnPool, tblname string, flds []string) (sql st
 		flds[fgeom] = fmt.Sprintf(`ST_AsBinary("%v") AS "%[1]v"`, l.geomField)
 	}
 
-	if !fgid {
+	if !fgid && l.idField != "" {
 		flds = append(flds, fmt.Sprintf(`"%v"`, l.idField))
 	}
 


### PR DESCRIPTION
- removed the unique ID check to match the mvt spec
which says IDs SHOULD be unique but is not a MUST.
- reworked mvt tests to closer align to the new testing
structure and remove the dependency on tbltest package