### PR TITLE
Issue 519

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Under the `maps` section, map layers are associated with data provider layers an
 [webserver]
 port = ":9090"              # port to bind the web server to. defaults ":8080"
 
+	[webserver.headers]
+	Access-Control-Allow-Origin = "*"
+	Cache-Control = "no-cache, no-store, must-revalidate"
+
 [cache]                     # configure a tile cache
 type = "file"               # a file cache will cache to the local file system
 basepath = "/tmp/tegola"    # where to write the file cache

--- a/cmd/tegola/cmd/server.go
+++ b/cmd/tegola/cmd/server.go
@@ -53,6 +53,9 @@ var serverCmd = &cobra.Command{
 		}
 		server.CORSAllowedMethods = header
 
+		// set the http reply headers
+		server.Headers = conf.Webserver.Headers
+
 		// set tile buffer
 		if conf.TileBuffer != nil {
 			server.TileBuffer = float64(*conf.TileBuffer)

--- a/cmd/tegola_lambda/main.go
+++ b/cmd/tegola_lambda/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/arolek/algnhsa"
-
 	"github.com/go-spatial/tegola/atlas"
 	"github.com/go-spatial/tegola/cmd/internal/register"
 	"github.com/go-spatial/tegola/config"
@@ -18,6 +17,11 @@ import (
 
 // set at build time via the CI
 var Version = "version not set"
+
+var (
+	defaultCORSAllowedOrigin  = "*"
+	defaultCORSAllowedMethods = "GET, OPTIONS"
+)
 
 func init() {
 	// override the URLRoot func with a lambda specific one
@@ -81,10 +85,19 @@ func main() {
 		server.HostName = string(conf.Webserver.HostName)
 	}
 
-	// set the CORSAllowedOrigin if a value is provided
-	if conf.Webserver.CORSAllowedOrigin != "" {
-		server.CORSAllowedOrigin = string(conf.Webserver.CORSAllowedOrigin)
+	// set the CORSAllowedOrigin to configured or default value
+	header, err := conf.Webserver.Headers.String("Access-Control-Allow-Origin", &defaultCORSAllowedOrigin)
+	if err != nil {
+		log.Fatal(err)
 	}
+	server.CORSAllowedOrigin = header
+
+	// set the CORSAllowedMethods to configured or default value
+	header, err = conf.Webserver.Headers.String("Access-Control-Allow-Methods", &defaultCORSAllowedMethods)
+	if err != nil {
+		log.Fatal(err)
+	}
+	server.CORSAllowedMethods = header
 
 	// set tile buffer
 	if conf.TileBuffer != nil {

--- a/cmd/tegola_lambda/main.go
+++ b/cmd/tegola_lambda/main.go
@@ -99,6 +99,9 @@ func main() {
 	}
 	server.CORSAllowedMethods = header
 
+	// set the http reply headers
+	server.Headers = conf.Webserver.Headers
+
 	// set tile buffer
 	if conf.TileBuffer != nil {
 		server.TileBuffer = float64(*conf.TileBuffer)

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-
 	"github.com/go-spatial/tegola"
 	"github.com/go-spatial/tegola/internal/env"
 	"github.com/go-spatial/tegola/internal/log"
@@ -34,9 +33,9 @@ type Config struct {
 }
 
 type Webserver struct {
-	HostName          env.String `toml:"hostname"`
-	Port              env.String `toml:"port"`
-	CORSAllowedOrigin env.String `toml:"cors_allowed_origin"`
+	HostName env.String `toml:"hostname"`
+	Port     env.String `toml:"port"`
+	Headers  env.Dict   `toml:"headers"`
 }
 
 // A Map represents a map in the Tegola Config file.

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,8 @@ import (
 	"github.com/go-spatial/tegola/internal/log"
 )
 
+var blacklistHeaders = []string{"content-encoding", "content-length", "content-type"}
+
 // Config represents a tegola config file.
 type Config struct {
 	// the tile buffer to use
@@ -122,6 +124,15 @@ func (c *Config) Validate() error {
 
 			// add the MapLayer to our map
 			mapLayers[string(m.Name)][name] = l
+		}
+	}
+
+	// check for blacklisted headers
+	for k := range c.Webserver.Headers {
+		for _, v := range blacklistHeaders {
+			if v == strings.ToLower(k) {
+				return ErrInvalidHeader{Header: k}
+			}
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -697,6 +697,76 @@ func TestValidate(t *testing.T) {
 				ProviderLayer2: "provider2.water_default_z",
 			},
 		},
+		"6 blocked headers": {
+			config: config.Config{
+				LocationName: "",
+				Webserver: config.Webserver{
+					Port: ":8080",
+					Headers: env.Dict{
+						"Content-Encoding": "plain/text",
+					},
+				},
+				Providers: []env.Dict{
+					{
+						"name":     "provider1",
+						"type":     "postgis",
+						"host":     "localhost",
+						"port":     int64(5432),
+						"database": "osm_water",
+						"user":     "admin",
+						"password": "",
+						"layers": []map[string]interface{}{
+							{
+								"name":               "water",
+								"geometry_fieldname": "geom",
+								"id_fieldname":       "gid",
+								"sql":                "SELECT gid, ST_AsBinary(geom) AS geom FROM simplified_water_polygons WHERE geom && !BBOX!",
+							},
+						},
+					},
+					{
+						"name":     "provider2",
+						"type":     "postgis",
+						"host":     "localhost",
+						"port":     int64(5432),
+						"database": "osm_water",
+						"user":     "admin",
+						"password": "",
+						"layers": []map[string]interface{}{
+							{
+								"name":               "water",
+								"geometry_fieldname": "geom",
+								"id_fieldname":       "gid",
+								"sql":                "SELECT gid, ST_AsBinary(geom) AS geom FROM simplified_water_polygons WHERE geom && !BBOX!",
+							},
+						},
+					},
+				},
+				Maps: []config.Map{
+					{
+						Name:        "osm",
+						Attribution: "Test Attribution",
+						Bounds:      []env.Float{-180, -85.05112877980659, 180, 85.0511287798066},
+						Center:      [3]env.Float{-76.275329586789, 39.153492567373, 8.0},
+						Layers: []config.MapLayer{
+							{
+								ProviderLayer: "provider1.water",
+								MinZoom:       env.UintPtr(10),
+								MaxZoom:       env.UintPtr(15),
+							},
+							{
+								ProviderLayer: "provider2.water",
+								MinZoom:       env.UintPtr(16),
+								MaxZoom:       env.UintPtr(20),
+							},
+						},
+					},
+				},
+			},
+			expectedErr: config.ErrInvalidHeader{
+				Header: "Content-Encoding",
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -99,6 +99,10 @@ func TestParse(t *testing.T) {
 				port = ":8080"
 				cors_allowed_origin = "tegola.io"
 
+					[webserver.headers]
+					Access-Control-Allow-Origin = "*"
+					Access-Control-Allow-Methods = "GET, OPTIONS"
+
 				[cache]
 				type = "file"
 				basepath = "/tmp/tegola-cache"
@@ -133,9 +137,12 @@ func TestParse(t *testing.T) {
 				TileBuffer:   env.IntPtr(env.Int(12)),
 				LocationName: "",
 				Webserver: config.Webserver{
-					HostName:          "cdn.tegola.io",
-					Port:              ":8080",
-					CORSAllowedOrigin: "tegola.io",
+					HostName: "cdn.tegola.io",
+					Port:     ":8080",
+					Headers: env.Dict{
+						"Access-Control-Allow-Origin":  "*",
+						"Access-Control-Allow-Methods": "GET, OPTIONS",
+					},
 				},
 				Cache: env.Dict{
 					"type":     "file",

--- a/config/errors.go
+++ b/config/errors.go
@@ -52,3 +52,11 @@ type ErrMissingEnvVar struct {
 func (e ErrMissingEnvVar) Error() string {
 	return fmt.Sprintf("config: config file is referencing an environment variable that is not set (%v)", e.EnvVar)
 }
+
+type ErrInvalidHeader struct {
+	Header string
+}
+
+func (e ErrInvalidHeader) Error() string {
+	return fmt.Sprintf("config: header (%v) blacklisted", e.Header)
+}

--- a/server/middleware_cors.go
+++ b/server/middleware_cors.go
@@ -6,7 +6,7 @@ func CORSHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Access-Control-Allow-Origin", CORSAllowedOrigin)
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", CORSAllowedMethods)
 
 		// stop here if the request is an OPTIONS preflight
 		if r.Method == "OPTIONS" {

--- a/server/middleware_headers.go
+++ b/server/middleware_headers.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+)
+
+func HeadersHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		for name, value := range Headers {
+			// skip CORS headers
+			if strings.ToLower(name) == "access-control-allow-origin" {
+				continue
+			}
+			if strings.ToLower(name) == "access-control-allow-methods" {
+				continue
+			}
+
+			v, ok := value.(string)
+			if ok {
+				w.Header().Set(name, v)
+			}
+		}
+
+		next.ServeHTTP(w, r)
+
+		return
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/dimfeld/httptreemux"
-
 	"github.com/go-spatial/tegola"
 	"github.com/go-spatial/tegola/atlas"
 	"github.com/go-spatial/tegola/internal/log"
@@ -35,6 +34,9 @@ var (
 	// CORSAllowedOrigin is the "Access-Control-Allow-Origin" CORS header.
 	// configurable via the tegola config.toml file (set in main.go)
 	CORSAllowedOrigin string = "*"
+
+	// CORSAllowedMethods is the "Access-Control-Allow-Methods" CORS header.
+	CORSAllowedMethods string = "GET, OPTIONS"
 
 	// TileBuffer is the tile buffer to use.
 	// configurable via tegola config.tomal file (set in main.go)
@@ -148,6 +150,6 @@ var URLRoot = func(r *http.Request) string {
 // corsHanlder is used to respond to all OPTIONS requests for registered routes
 func corsHandler(w http.ResponseWriter, r *http.Request, params map[string]string) {
 	w.Header().Set("Access-Control-Allow-Origin", CORSAllowedOrigin)
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Methods", CORSAllowedMethods)
 	return
 }

--- a/server/server.go
+++ b/server/server.go
@@ -36,7 +36,12 @@ var (
 	CORSAllowedOrigin string = "*"
 
 	// CORSAllowedMethods is the "Access-Control-Allow-Methods" CORS header.
+	// configurable via the tegola config.toml file (set in main.go)
 	CORSAllowedMethods string = "GET, OPTIONS"
+
+	// Headers is the map of http reply headers.
+	// configurable via the tegola config.toml file (set in main.go)
+	Headers map[string]interface{}
 
 	// TileBuffer is the tile buffer to use.
 	// configurable via tegola config.tomal file (set in main.go)
@@ -52,16 +57,16 @@ func NewRouter(a *atlas.Atlas) *httptreemux.TreeMux {
 	r.OptionsHandler = corsHandler
 
 	// capabilities endpoints
-	group.UsingContext().Handler("GET", "/capabilities", CORSHandler(HandleCapabilities{}))
-	group.UsingContext().Handler("GET", "/capabilities/:map_name", CORSHandler(HandleMapCapabilities{}))
+	group.UsingContext().Handler("GET", "/capabilities", HeadersHandler(CORSHandler(HandleCapabilities{})))
+	group.UsingContext().Handler("GET", "/capabilities/:map_name", HeadersHandler(CORSHandler(HandleMapCapabilities{})))
 
 	// map tiles
 	hMapLayerZXY := HandleMapLayerZXY{Atlas: a}
-	group.UsingContext().Handler("GET", "/maps/:map_name/:z/:x/:y", CORSHandler(GZipHandler(TileCacheHandler(a, hMapLayerZXY))))
-	group.UsingContext().Handler("GET", "/maps/:map_name/:layer_name/:z/:x/:y", CORSHandler(GZipHandler(TileCacheHandler(a, hMapLayerZXY))))
+	group.UsingContext().Handler("GET", "/maps/:map_name/:z/:x/:y", HeadersHandler(CORSHandler(GZipHandler(TileCacheHandler(a, hMapLayerZXY)))))
+	group.UsingContext().Handler("GET", "/maps/:map_name/:layer_name/:z/:x/:y", HeadersHandler(CORSHandler(GZipHandler(TileCacheHandler(a, hMapLayerZXY)))))
 
 	// map style
-	group.UsingContext().Handler("GET", "/maps/:map_name/style.json", CORSHandler(HandleMapStyle{}))
+	group.UsingContext().Handler("GET", "/maps/:map_name/style.json", HeadersHandler(CORSHandler(HandleMapStyle{})))
 
 	// setup viewer routes, which can be excluded via build flags
 	setupViewer(group)


### PR DESCRIPTION
This PR adds ability to configure webserver response headers:

```toml
[webserver.headers]
Access-Control-Allow-Origin = "map.example.com"
Cache-Control = "no-cache, no-store, must-revalidate"
```

If "Access-Control-Allow-Origin" and "Access-Control-Allow-Methods" is not set, use default values:
```
Access-Control-Allow-Methods: GET, OPTIONS
Access-Control-Allow-Origin: *
```

Some headers blacklisted and can not be changed (config/config.go: blacklistHeaders)