### PR TITLE
Double seeding of cache when using tile-list

### DIFF
--- a/cmd/tegola/cmd/cache/seed_purge.go
+++ b/cmd/tegola/cmd/cache/seed_purge.go
@@ -104,7 +104,7 @@ func seedPurgeCmdValidatePersistent(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		seedPurgeMaps = append(seedPurgeMaps, m)
+		seedPurgeMaps = []atlas.Map{m}
 	} else {
 		seedPurgeMaps = atlas.AllMaps()
 		if len(seedPurgeMaps) == 0 {


### PR DESCRIPTION
when the --map flag is used the map was set twice as the
seedPurgeCmdValidatePersistent method is called twice.
this commit makes the method idempotent but does not address
the double call.

closes #553