### PR TITLE
Use a hard-coded zoom level when inspecting geom type

### DIFF
--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -431,7 +431,7 @@ func (p Provider) inspectLayerGeomType(l *Layer) error {
 
 	// if a !ZOOM! token exists, all features could be filtered out so we don't have a geometry to inspect it's type.
 	// address this by replacing the !ZOOM! token with an ANY statement which includes all zooms
-	sql = strings.Replace(sql, "!ZOOM!", "ANY('{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}')", 1)
+	sql = strings.Replace(sql, "!ZOOM!", "24", 1)
 
 	// we need a tile to run our sql through the replacer
 	tile := slippy.NewTile(0, 0, 0, 64, tegola.WebMercator)

--- a/server/README.md
+++ b/server/README.md
@@ -5,13 +5,15 @@ The server package is responsible for handling webserver requests for map tiles 
 ```toml
 [webserver]
 port = ":9090" # set something different than default ":8080"
+
+[webserver.headers]
+Access-Control-Allow-Origin = "*"
 ```
 
 ### Config properties
 
 - `port` (string): [Optional] Port and bind string. For example ":9090" or "127.0.0.1:9090". Defaults to ":8080"
 - `hostname` (string): [Optional] The hostname to use in the various JSON endpoints. This is useful if tegola is behind a proxy and can't read the API consumer's request host directly.
-- `cors_allowed_origin` (string): [Optional] The value to include with the Cross Origin Resource Sharing (CORS) `Access-Control-Allow-Origin` header. Defaults to `*`.
 
 ## Local development of the embedded viewer
 


### PR DESCRIPTION
This resolves #343, although not in the most ideal way. I've been
running with this patch on openinframap.org for a few months so I
think it's worth documenting it.

As far as I'm aware, the only situation in which this would cause a
problem is if a layer's SQL has a zoom filter which filters out all
objects at zoom 24, but displays them at lower zooms.

I'm not sure if this is a common situation (it isn't in my
configuration), and I don't necessarily expect this patch to be
merged. I'm providing it so it's available to others as an option, in
the absence of a better solution.