### PR TITLE
make better performance by Remove not needed sort

### DIFF
--- a/maths/line_intersect.go
+++ b/maths/line_intersect.go
@@ -185,7 +185,6 @@ func FindIntersectsWithEventQueue(polygonCheck bool, eq []event, segments []Line
 		for s := range isegmap {
 			sslice = append(sslice, s)
 		}
-		sort.Ints(sslice)
 
 		for _, s := range sslice {
 


### PR DESCRIPTION
I think we don't need sort.Ints in FindIntersectsWithEventQueueWithoutIntersect function.
It makes decrease 30%-50%  time to render tiles for me.