### PR TITLE
Fixed tile buffer not being set correctly #573

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -147,13 +147,13 @@ func (c *Config) ConfigureTileBuffers() {
 		// if there is a tile buffer config for this map, use it
 		if m.TileBuffer != nil {
 			c.Maps[mapKey].TileBuffer = m.TileBuffer
-			return
+			continue
 		}
 
 		// if there is a global tile buffer config, use it
 		if c.TileBuffer != nil {
 			c.Maps[mapKey].TileBuffer = c.TileBuffer
-			return
+			continue
 		}
 
 		// tile buffer is not configured, use default

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -765,6 +765,9 @@ func TestConfigureTileBuffers(t *testing.T) {
 					{
 						Name: "osm",
 					},
+					{
+						Name: "osm-2",
+					},
 				},
 			},
 			expected: config.Config{
@@ -772,6 +775,10 @@ func TestConfigureTileBuffers(t *testing.T) {
 				Maps: []config.Map{
 					{
 						Name:       "osm",
+						TileBuffer: env.IntPtr(env.Int(32)),
+					},
+					{
+						Name:       "osm-2",
 						TileBuffer: env.IntPtr(env.Int(32)),
 					},
 				},
@@ -784,6 +791,10 @@ func TestConfigureTileBuffers(t *testing.T) {
 						Name:       "osm",
 						TileBuffer: env.IntPtr(env.Int(16)),
 					},
+					{
+						Name:       "osm-2",
+						TileBuffer: env.IntPtr(env.Int(32)),
+					},
 				},
 			},
 			expected: config.Config{
@@ -791,6 +802,10 @@ func TestConfigureTileBuffers(t *testing.T) {
 					{
 						Name:       "osm",
 						TileBuffer: env.IntPtr(env.Int(16)),
+					},
+					{
+						Name:       "osm-2",
+						TileBuffer: env.IntPtr(env.Int(32)),
 					},
 				},
 			},


### PR DESCRIPTION
Addressed issue where map tile buffers were not being set correctly
for configured maps 2+. This was due to a return statement when
a continue should have been used. Updated test cases accordingly.