### PR TITLE
provider/postgis: no error thrown when geoFieldname is missing

### DIFF
--- a/provider/postgis/error.go
+++ b/provider/postgis/error.go
@@ -21,3 +21,12 @@ type ErrUnclosedToken string
 func (e ErrUnclosedToken) Error() string {
 	return fmt.Sprintf("postgis: unclosed token in (%v)", string(e))
 }
+
+type ErrGeomFieldNotFound struct {
+	GeomFieldName string
+	LayerName     string
+}
+
+func (e ErrGeomFieldNotFound) Error() string {
+	return fmt.Sprintf("postgis: geom fieldname (%v) not found for layer (%v)", e.GeomFieldName, e.LayerName)
+}

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -539,6 +539,21 @@ func (p Provider) TileFeatures(ctx context.Context, layer string, tile provider.
 	// fetch rows FieldDescriptions. this gives us the OID for the data types returned to aid in decoding
 	fdescs := rows.FieldDescriptions()
 
+	// loop our field descriptions looking for the geometry field
+	var geomFieldFound bool
+	for i := range fdescs {
+		if fdescs[i].Name == plyr.GeomFieldName() {
+			geomFieldFound = true
+			break
+		}
+	}
+	if !geomFieldFound {
+		return ErrGeomFieldNotFound{
+			GeomFieldName: plyr.GeomFieldName(),
+			LayerName:     plyr.Name(),
+		}
+	}
+
 	for rows.Next() {
 		// context check
 		if err := ctx.Err(); err != nil {

--- a/provider/postgis/util.go
+++ b/provider/postgis/util.go
@@ -189,8 +189,10 @@ func transformVal(valType pgtype.OID, val interface{}) (interface{}, error) {
 	}
 }
 
-func decipherFields(ctx context.Context, geoFieldname, idFieldname string, descriptions []pgx.FieldDescription, values []interface{}) (gid uint64, geom []byte, tags map[string]interface{}, err error) {
+// decipherFields is responsible for processing the SQL result set, decoding geometries, ids and feature tags.
+func decipherFields(ctx context.Context, geomFieldname, idFieldname string, descriptions []pgx.FieldDescription, values []interface{}) (gid uint64, geom []byte, tags map[string]interface{}, err error) {
 	var ok bool
+
 	tags = make(map[string]interface{})
 
 	for i := range values {
@@ -207,9 +209,9 @@ func decipherFields(ctx context.Context, geoFieldname, idFieldname string, descr
 		desc := descriptions[i]
 
 		switch desc.Name {
-		case geoFieldname:
+		case geomFieldname:
 			if geom, ok = values[i].([]byte); !ok {
-				return 0, nil, nil, fmt.Errorf("unable to convert geometry field (%v) into bytes.", geoFieldname)
+				return 0, nil, nil, fmt.Errorf("unable to convert geometry field (%v) into bytes.", geomFieldname)
 			}
 		case idFieldname:
 			gid, err = gId(values[i])
@@ -238,7 +240,7 @@ func decipherFields(ctx context.Context, geoFieldname, idFieldname string, descr
 		}
 	}
 
-	return gid, geom, tags, err
+	return gid, geom, tags, nil
 }
 
 func gId(v interface{}) (gid uint64, err error) {


### PR DESCRIPTION
Added a check to the result set field descripters of TileFeatures
to ensure the configured geom_fieldname is present. This catches
a misconfiguration error that may arise at runtime.

closes #590