### PR TITLE
Custom webserver headers are not added to OPTIONS requests

### DIFF
--- a/cmd/tegola/cmd/server.go
+++ b/cmd/tegola/cmd/server.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -36,8 +38,17 @@ var serverCmd = &cobra.Command{
 		server.Version = Version
 		server.HostName = string(conf.Webserver.HostName)
 
-		// set the http reply headers
-		server.Headers = conf.Webserver.Headers
+		// set user defined response headers
+		for name, value := range conf.Webserver.Headers {
+			// cast to string
+			val := fmt.Sprintf("%v", value)
+			// check that we have a value set
+			if val == "" {
+				log.Fatalf("webserver.header (%v) has no configured value", val)
+			}
+
+			server.Headers[name] = val
+		}
 
 		// start our webserver
 		srv := server.Start(nil, serverPort)

--- a/cmd/tegola_lambda/main.go
+++ b/cmd/tegola_lambda/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -80,8 +81,17 @@ func main() {
 		server.HostName = string(conf.Webserver.HostName)
 	}
 
-	// set the http reply headers
-	server.Headers = conf.Webserver.Headers
+	// set user defined response headers
+	for name, value := range conf.Webserver.Headers {
+		// cast to string
+		val := fmt.Sprintf("%v", value)
+		// check that we have a value set
+		if val == "" {
+			log.Fatalf("webserver.header (%v) has no configured value", val)
+		}
+
+		server.Headers[name] = val
+	}
 
 	// http route setup
 	mux := server.NewRouter(nil)

--- a/server/middleware_headers.go
+++ b/server/middleware_headers.go
@@ -2,6 +2,7 @@ package server
 
 import "net/http"
 
+// HeadersHandler is middleware for adding user defined response headers
 func HeadersHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -9,15 +10,19 @@ func HeadersHandler(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Origin", CORSAllowedOrigin)
 		w.Header().Set("Access-Control-Allow-Methods", CORSAllowedMethods)
 
-		for name, value := range Headers {
-			v, ok := value.(string)
-			if ok {
-				w.Header().Set(name, v)
-			}
-		}
+		addUserDefinedHeaders(w)
 
 		next.ServeHTTP(w, r)
 
 		return
 	})
+}
+
+func addUserDefinedHeaders(w http.ResponseWriter) {
+	for name, value := range Headers {
+		v, ok := value.(string)
+		if ok {
+			w.Header().Set(name, v)
+		}
+	}
 }

--- a/server/middleware_headers.go
+++ b/server/middleware_headers.go
@@ -5,24 +5,10 @@ import "net/http"
 // HeadersHandler is middleware for adding user defined response headers
 func HeadersHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-		// default CORS headers. may be overwritten by the user
-		w.Header().Set("Access-Control-Allow-Origin", CORSAllowedOrigin)
-		w.Header().Set("Access-Control-Allow-Methods", CORSAllowedMethods)
-
-		addUserDefinedHeaders(w)
-
+		// set default and user defined headers
+		setHeaders(w)
+		// move on
 		next.ServeHTTP(w, r)
-
 		return
 	})
-}
-
-func addUserDefinedHeaders(w http.ResponseWriter) {
-	for name, value := range Headers {
-		v, ok := value.(string)
-		if ok {
-			w.Header().Set(name, v)
-		}
-	}
 }

--- a/server/middleware_headers_test.go
+++ b/server/middleware_headers_test.go
@@ -62,8 +62,8 @@ func TestMiddlewareHeaders(t *testing.T) {
 			httpMethod:    http.MethodGet,
 			customHeaders: map[string]interface{}{},
 			expectedResponseHeaders: map[string]string{
-				"Access-Control-Allow-Origin":  server.CORSAllowedOrigin,
-				"Access-Control-Allow-Methods": server.CORSAllowedMethods,
+				"Access-Control-Allow-Origin":  DefaultCORSAllowedOrigin,
+				"Access-Control-Allow-Methods": DefaultCORSAllowedMethods,
 			},
 		},
 		"user defined headers GET": {
@@ -73,8 +73,8 @@ func TestMiddlewareHeaders(t *testing.T) {
 				"Test-Header": "tegola",
 			},
 			expectedResponseHeaders: map[string]string{
-				"Access-Control-Allow-Origin":  server.CORSAllowedOrigin,
-				"Access-Control-Allow-Methods": server.CORSAllowedMethods,
+				"Access-Control-Allow-Origin":  DefaultCORSAllowedOrigin,
+				"Access-Control-Allow-Methods": DefaultCORSAllowedMethods,
 				"Test-Header":                  "tegola",
 			},
 		},
@@ -95,8 +95,8 @@ func TestMiddlewareHeaders(t *testing.T) {
 			httpMethod:    http.MethodOptions,
 			customHeaders: map[string]interface{}{},
 			expectedResponseHeaders: map[string]string{
-				"Access-Control-Allow-Origin":  server.CORSAllowedOrigin,
-				"Access-Control-Allow-Methods": server.CORSAllowedMethods,
+				"Access-Control-Allow-Origin":  DefaultCORSAllowedOrigin,
+				"Access-Control-Allow-Methods": DefaultCORSAllowedMethods,
 			},
 		},
 		"user defined headers OPTIONS": {
@@ -106,8 +106,8 @@ func TestMiddlewareHeaders(t *testing.T) {
 				"Test-Header": "tegola",
 			},
 			expectedResponseHeaders: map[string]string{
-				"Access-Control-Allow-Origin":  server.CORSAllowedOrigin,
-				"Access-Control-Allow-Methods": server.CORSAllowedMethods,
+				"Access-Control-Allow-Origin":  DefaultCORSAllowedOrigin,
+				"Access-Control-Allow-Methods": DefaultCORSAllowedMethods,
 				"Test-Header":                  "tegola",
 			},
 		},

--- a/server/middleware_headers_test.go
+++ b/server/middleware_headers_test.go
@@ -13,7 +13,7 @@ func TestMiddlewareHeaders(t *testing.T) {
 	type tcase struct {
 		uri                     string
 		httpMethod              string
-		customHeaders           map[string]interface{}
+		customHeaders           map[string]string
 		expectedResponseHeaders map[string]string
 	}
 
@@ -60,7 +60,7 @@ func TestMiddlewareHeaders(t *testing.T) {
 		"default headers GET": {
 			uri:           "/maps/test-map/10/2/3.pbf",
 			httpMethod:    http.MethodGet,
-			customHeaders: map[string]interface{}{},
+			customHeaders: map[string]string{},
 			expectedResponseHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  DefaultCORSAllowedOrigin,
 				"Access-Control-Allow-Methods": DefaultCORSAllowedMethods,
@@ -69,7 +69,7 @@ func TestMiddlewareHeaders(t *testing.T) {
 		"user defined headers GET": {
 			uri:        "/maps/test-map/10/2/3.pbf",
 			httpMethod: http.MethodGet,
-			customHeaders: map[string]interface{}{
+			customHeaders: map[string]string{
 				"Test-Header": "tegola",
 			},
 			expectedResponseHeaders: map[string]string{
@@ -81,7 +81,7 @@ func TestMiddlewareHeaders(t *testing.T) {
 		"user defined cors override GET": {
 			uri:        "/maps/test-map/10/2/3.pbf",
 			httpMethod: http.MethodGet,
-			customHeaders: map[string]interface{}{
+			customHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "tegola.io",
 				"Access-Control-Allow-Methods": "GET, POST",
 			},
@@ -93,7 +93,7 @@ func TestMiddlewareHeaders(t *testing.T) {
 		"default headers OPTIONS": {
 			uri:           "/maps/test-map/10/2/3.pbf",
 			httpMethod:    http.MethodOptions,
-			customHeaders: map[string]interface{}{},
+			customHeaders: map[string]string{},
 			expectedResponseHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  DefaultCORSAllowedOrigin,
 				"Access-Control-Allow-Methods": DefaultCORSAllowedMethods,
@@ -102,7 +102,7 @@ func TestMiddlewareHeaders(t *testing.T) {
 		"user defined headers OPTIONS": {
 			uri:        "/maps/test-map/10/2/3.pbf",
 			httpMethod: http.MethodOptions,
-			customHeaders: map[string]interface{}{
+			customHeaders: map[string]string{
 				"Test-Header": "tegola",
 			},
 			expectedResponseHeaders: map[string]string{
@@ -114,7 +114,7 @@ func TestMiddlewareHeaders(t *testing.T) {
 		"user defined cors override OPTIONS": {
 			uri:        "/maps/test-map/10/2/3.pbf",
 			httpMethod: http.MethodOptions,
-			customHeaders: map[string]interface{}{
+			customHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "tegola.io",
 				"Access-Control-Allow-Methods": "GET, POST",
 			},

--- a/server/middleware_headers_test.go
+++ b/server/middleware_headers_test.go
@@ -1,0 +1,131 @@
+package server_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-spatial/tegola/cache/memory"
+	"github.com/go-spatial/tegola/server"
+)
+
+func TestMiddlewareHeaders(t *testing.T) {
+	type tcase struct {
+		uri                     string
+		httpMethod              string
+		customHeaders           map[string]interface{}
+		expectedResponseHeaders map[string]string
+	}
+
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			var err error
+
+			// set the custom headers in the server package
+			server.Headers = tc.customHeaders
+
+			// setup a new atlas
+			a := newTestMapWithLayers(testLayer1, testLayer2, testLayer3)
+			cacher, _ := memory.New(nil)
+			a.SetCache(cacher)
+
+			// setup a new router
+			router := server.NewRouter(a)
+
+			// setup a new request
+			r, err := http.NewRequest(tc.httpMethod, tc.uri, nil)
+			if err != nil {
+				t.Errorf("unexecpted err: %v", err)
+				return
+			}
+
+			// new recorder to capture the response
+			w := httptest.NewRecorder()
+
+			// issue the request
+			router.ServeHTTP(w, r)
+
+			// check our response for the correct headers
+			for k, v := range tc.expectedResponseHeaders {
+				h := w.Header().Get(k)
+				if h != v {
+					t.Errorf("expected header (%v) to have value (%v) got (%v)", k, v, h)
+					return
+				}
+			}
+		}
+	}
+
+	tests := map[string]tcase{
+		"default headers GET": {
+			uri:           "/maps/test-map/10/2/3.pbf",
+			httpMethod:    http.MethodGet,
+			customHeaders: map[string]interface{}{},
+			expectedResponseHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  server.CORSAllowedOrigin,
+				"Access-Control-Allow-Methods": server.CORSAllowedMethods,
+			},
+		},
+		"user defined headers GET": {
+			uri:        "/maps/test-map/10/2/3.pbf",
+			httpMethod: http.MethodGet,
+			customHeaders: map[string]interface{}{
+				"Test-Header": "tegola",
+			},
+			expectedResponseHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  server.CORSAllowedOrigin,
+				"Access-Control-Allow-Methods": server.CORSAllowedMethods,
+				"Test-Header":                  "tegola",
+			},
+		},
+		"user defined cors override GET": {
+			uri:        "/maps/test-map/10/2/3.pbf",
+			httpMethod: http.MethodGet,
+			customHeaders: map[string]interface{}{
+				"Access-Control-Allow-Origin":  "tegola.io",
+				"Access-Control-Allow-Methods": "GET, POST",
+			},
+			expectedResponseHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  "tegola.io",
+				"Access-Control-Allow-Methods": "GET, POST",
+			},
+		},
+		"default headers OPTIONS": {
+			uri:           "/maps/test-map/10/2/3.pbf",
+			httpMethod:    http.MethodOptions,
+			customHeaders: map[string]interface{}{},
+			expectedResponseHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  server.CORSAllowedOrigin,
+				"Access-Control-Allow-Methods": server.CORSAllowedMethods,
+			},
+		},
+		"user defined headers OPTIONS": {
+			uri:        "/maps/test-map/10/2/3.pbf",
+			httpMethod: http.MethodOptions,
+			customHeaders: map[string]interface{}{
+				"Test-Header": "tegola",
+			},
+			expectedResponseHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  server.CORSAllowedOrigin,
+				"Access-Control-Allow-Methods": server.CORSAllowedMethods,
+				"Test-Header":                  "tegola",
+			},
+		},
+		"user defined cors override OPTIONS": {
+			uri:        "/maps/test-map/10/2/3.pbf",
+			httpMethod: http.MethodOptions,
+			customHeaders: map[string]interface{}{
+				"Access-Control-Allow-Origin":  "tegola.io",
+				"Access-Control-Allow-Methods": "GET, POST",
+			},
+			expectedResponseHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  "tegola.io",
+				"Access-Control-Allow-Methods": "GET, POST",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, fn(tc))
+	}
+}

--- a/server/middleware_tile_cache.go
+++ b/server/middleware_tile_cache.go
@@ -69,9 +69,6 @@ func TileCacheHandler(a *atlas.Atlas, next http.Handler) http.Handler {
 			return
 		}
 
-		//	cors header
-		w.Header().Set("Access-Control-Allow-Origin", CORSAllowedOrigin)
-
 		// mimetype for mapbox vector tiles
 		w.Header().Add("Content-Type", mvt.MimeType)
 

--- a/server/server.go
+++ b/server/server.go
@@ -151,5 +151,8 @@ var URLRoot = func(r *http.Request) string {
 func corsHandler(w http.ResponseWriter, r *http.Request, params map[string]string) {
 	w.Header().Set("Access-Control-Allow-Origin", CORSAllowedOrigin)
 	w.Header().Set("Access-Control-Allow-Methods", CORSAllowedMethods)
+
+	addUserDefinedHeaders(w)
+
 	return
 }

--- a/server/server.go
+++ b/server/server.go
@@ -166,7 +166,7 @@ func setHeaders(w http.ResponseWriter) {
 	// set user defined headers
 	for name, val := range Headers {
 		if val == "" {
-			log.Warnf("header (%v) has no value")
+			log.Warnf("header (%v) has no value", val)
 		}
 
 		w.Header().Set(name, val)

--- a/server/server.go
+++ b/server/server.go
@@ -166,7 +166,7 @@ func setHeaders(w http.ResponseWriter) {
 	// set user defined headers
 	for name, val := range Headers {
 		if val == "" {
-			log.Warn("header (%v) has no value")
+			log.Warnf("header (%v) has no value")
 		}
 
 		w.Header().Set(name, val)

--- a/server/server.go
+++ b/server/server.go
@@ -157,7 +157,7 @@ func setHeaders(w http.ResponseWriter) {
 	// add our default CORS headers
 	for name, val := range DefaultCORSHeaders {
 		if val == "" {
-			log.Warn("default CORS header (%v) has no value")
+			log.Warnf("default CORS header (%v) has no value", name)
 		}
 
 		w.Header().Set(name, val)
@@ -166,7 +166,7 @@ func setHeaders(w http.ResponseWriter) {
 	// set user defined headers
 	for name, val := range Headers {
 		if val == "" {
-			log.Warnf("header (%v) has no value", val)
+			log.Warnf("header (%v) has no value", name)
 		}
 
 		w.Header().Set(name, val)

--- a/server/server.go
+++ b/server/server.go
@@ -1,4 +1,4 @@
-//  Package server implements the http frontend
+// Package server implements the http frontend
 package server
 
 import (
@@ -30,17 +30,15 @@ var (
 	// configurable via the tegola config.toml file (set in main.go)
 	Port string
 
-	// CORSAllowedOrigin is the "Access-Control-Allow-Origin" CORS header.
-	// configurable via the tegola config.toml file (set in main.go)
-	CORSAllowedOrigin string = "*"
-
-	// CORSAllowedMethods is the "Access-Control-Allow-Methods" CORS header.
-	// configurable via the tegola config.toml file (set in main.go)
-	CORSAllowedMethods string = "GET, OPTIONS"
-
-	// Headers is the map of http reply headers.
+	// Headers is the map of user defined response headers.
 	// configurable via the tegola config.toml file (set in main.go)
 	Headers map[string]interface{}
+
+	// DefaultCORSHeaders define the default CORS response headers added to all requests
+	DefaultCORSHeaders = map[string]interface{}{
+		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Methods": "GET, OPTIONS",
+	}
 )
 
 // NewRouter set's up the our routes.
@@ -149,10 +147,25 @@ var URLRoot = func(r *http.Request) string {
 
 // corsHanlder is used to respond to all OPTIONS requests for registered routes
 func corsHandler(w http.ResponseWriter, r *http.Request, params map[string]string) {
-	w.Header().Set("Access-Control-Allow-Origin", CORSAllowedOrigin)
-	w.Header().Set("Access-Control-Allow-Methods", CORSAllowedMethods)
-
-	addUserDefinedHeaders(w)
-
+	setHeaders(w)
 	return
+}
+
+// setHeaders sets deafult headers and user defined headers
+func setHeaders(w http.ResponseWriter) {
+	// add our default CORS headers
+	for name, value := range DefaultCORSHeaders {
+		v, ok := value.(string)
+		if ok {
+			w.Header().Set(name, v)
+		}
+	}
+
+	// set user defined headers
+	for name, value := range Headers {
+		v, ok := value.(string)
+		if ok {
+			w.Header().Set(name, v)
+		}
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/dimfeld/httptreemux"
+
 	"github.com/go-spatial/tegola/atlas"
 	"github.com/go-spatial/tegola/internal/log"
 )
@@ -32,10 +33,10 @@ var (
 
 	// Headers is the map of user defined response headers.
 	// configurable via the tegola config.toml file (set in main.go)
-	Headers map[string]interface{}
+	Headers = map[string]string{}
 
 	// DefaultCORSHeaders define the default CORS response headers added to all requests
-	DefaultCORSHeaders = map[string]interface{}{
+	DefaultCORSHeaders = map[string]string{
 		"Access-Control-Allow-Origin":  "*",
 		"Access-Control-Allow-Methods": "GET, OPTIONS",
 	}
@@ -154,18 +155,20 @@ func corsHandler(w http.ResponseWriter, r *http.Request, params map[string]strin
 // setHeaders sets deafult headers and user defined headers
 func setHeaders(w http.ResponseWriter) {
 	// add our default CORS headers
-	for name, value := range DefaultCORSHeaders {
-		v, ok := value.(string)
-		if ok {
-			w.Header().Set(name, v)
+	for name, val := range DefaultCORSHeaders {
+		if val == "" {
+			log.Warn("default CORS header (%v) has no value")
 		}
+
+		w.Header().Set(name, val)
 	}
 
 	// set user defined headers
-	for name, value := range Headers {
-		v, ok := value.(string)
-		if ok {
-			w.Header().Set(name, v)
+	for name, val := range Headers {
+		if val == "" {
+			log.Warn("header (%v) has no value")
 		}
+
+		w.Header().Set(name, val)
 	}
 }

--- a/server/server_cors_test.go
+++ b/server/server_cors_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/go-spatial/tegola/server"
 )
 
+const (
+	DefaultCORSAllowedOrigin  = "*"
+	DefaultCORSAllowedMethods = "GET, OPTIONS"
+)
+
 type CORSTestCase struct {
 	hostname string
 	port     string
@@ -40,8 +45,8 @@ func CORSTest(t *testing.T, tc CORSTestCase) {
 
 	headers := w.Header()
 
-	if !reflect.DeepEqual(headers["Access-Control-Allow-Origin"], []string{server.CORSAllowedOrigin}) {
-		t.Errorf("wrong header for Access-Control-Allow-Origin. expected %v got %v", server.CORSAllowedOrigin, headers["Access-Control-Allow-Origin"])
+	if !reflect.DeepEqual(headers["Access-Control-Allow-Origin"], []string{DefaultCORSAllowedOrigin}) {
+		t.Errorf("wrong header for Access-Control-Allow-Origin. expected %v got %v", DefaultCORSAllowedOrigin, headers["Access-Control-Allow-Origin"])
 		return
 	}
 


### PR DESCRIPTION
* Fixed bug where user defined headers were not being added
to OPTIONS requests.
* Added associated tests.

closes #594