### PR TITLE
Move geometry processing out of mvt package

### DIFF
--- a/example/tile.go
+++ b/example/tile.go
@@ -8,7 +8,6 @@ import (
 	"context"
 
 	"github.com/go-spatial/geom/encoding/wkb"
-	"github.com/go-spatial/tegola"
 	"github.com/go-spatial/tegola/internal/convert"
 	"github.com/go-spatial/tegola/mvt"
 	"github.com/golang/protobuf/proto"
@@ -78,8 +77,7 @@ func TileExample() {
 
 	// VTile is the protobuff representation of the tile. This is what you can
 	// send to the protobuff Marshal functions.
-	ttile := tegola.NewTile(0, 0, 0)
-	vtile, err := tile.VTile(context.Background(), ttile)
+	vtile, err := tile.VTile(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/mvt/debug.go
+++ b/mvt/debug.go
@@ -1,3 +1,47 @@
 package mvt
 
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/go-spatial/tegola"
+	"github.com/go-spatial/tegola/basic"
+	"github.com/go-spatial/tegola/internal/log"
+	"github.com/go-spatial/tegola/maths"
+)
+
 const debug = false
+
+type geoDebugStruct struct {
+	Min maths.Pt       `json:"min"`
+	Max maths.Pt       `json:"max"`
+	Geo basic.Geometry `json:"geo"`
+}
+
+func createDebugFile(min, max maths.Pt, geo tegola.Geometry, err error) {
+	fln := os.Getenv("GenTestCase")
+	if fln == "" {
+		return
+	}
+	filename := fmt.Sprintf("/tmp/testcase_%v_%p.json", fln, geo)
+	bgeo, err := basic.CloneGeometry(geo)
+	if err != nil {
+		log.Errorf("failed to clone geo for test case. %v", err)
+		return
+	}
+	f, err := os.Create(filename)
+	if err != nil {
+		log.Errorf("failed to create test file %v : %v.", filename, err)
+		return
+	}
+	defer f.Close()
+	geodebug := geoDebugStruct{
+		Max: max,
+		Min: min,
+		Geo: bgeo,
+	}
+	enc := json.NewEncoder(f)
+	enc.Encode(geodebug)
+	log.Infof("created file: %v", filename)
+}

--- a/mvt/layer.go
+++ b/mvt/layer.go
@@ -4,102 +4,63 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"log"
-	"os"
-	"strconv"
-	"strings"
 
 	"context"
 
-	"github.com/go-spatial/tegola"
-	"github.com/go-spatial/tegola/mvt/vector_tile"
+	vectorTile "github.com/go-spatial/tegola/mvt/vector_tile"
 )
 
-var simplifyGeometries = true
-var simplificationMaxZoom = 10
-
-func init() {
-	options := strings.ToLower(os.Getenv("TEGOLA_OPTIONS"))
-	if strings.Contains(options, "dontsimplifygeo") {
-		simplifyGeometries = false
-		log.Println("Turning Off Simplification of Geometries.")
-	}
-	if strings.Contains(options, "simplifymaxzoom=") {
-		idx := strings.Index(options, "simplifymaxzoom=")
-		idx += 16
-		eidx := strings.IndexAny(options[idx:], ",.\t \n")
-
-		if eidx == -1 {
-			eidx = len(options)
-		} else {
-			eidx += idx
-		}
-		i, err := strconv.Atoi(options[idx:eidx])
-		if err != nil {
-			log.Printf("Did not under the value(%v) for SimplifyMaxZoom sticking with default (%v).", options[idx:eidx], simplificationMaxZoom)
-			return
-		}
-		simplificationMaxZoom = int(i + 1)
-		log.Printf("Setting SimplifyMaxZoom to %v", int(i))
-	}
-}
-
-// Layer describes a layer in the tile. Each layer can have multiple features
-// which describe drawing.
+// Layer describes a layer within a tile.
+// Each layer can have multiple features
 type Layer struct {
-	// This is the name of the feature, is has to be unique within a tile.
+	// Name is the unique name of the layer within the tile
 	Name string
 	// The set of features
 	features []Feature
-	extent   *int // default is 4096
-	// DontSimplify truns off simplification for this layer.
-	DontSimplify bool
-	// MaxSimplificationZoom is the zoom level at which point simplification is turned off. if value is zero Max is set to 14. If you do not want to simplify at any level set DontSimplify to true.
-	MaxSimplificationZoom uint
-	// DontClip truns off clipping for this layer.
-	DontClip bool
+	// default is 4096
+	extent *int
 }
 
 func valMapToVTileValue(valMap []interface{}) (vt []*vectorTile.Tile_Value) {
 	for _, v := range valMap {
 		vt = append(vt, vectorTileValue(v))
 	}
+
 	return vt
 }
 
 // VTileLayer returns a vectorTile Tile_Layer object that represents this layer.
-func (l *Layer) VTileLayer(ctx context.Context, tile *tegola.Tile) (*vectorTile.Tile_Layer, error) {
+func (l *Layer) VTileLayer(ctx context.Context) (*vectorTile.Tile_Layer, error) {
 	kmap, vmap, err := keyvalMapsFromFeatures(l.features)
 	if err != nil {
 		return nil, err
 	}
+
 	valmap := valMapToVTileValue(vmap)
+
 	var features = make([]*vectorTile.Tile_Feature, 0, len(l.features))
 	for _, f := range l.features {
+		// context check
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		simplify := simplifyGeometries && !l.DontSimplify
-		if l.MaxSimplificationZoom == 0 {
-			l.MaxSimplificationZoom = uint(simplificationMaxZoom)
-		}
 
-		simplify = simplify && tile.Z < l.MaxSimplificationZoom
-
-		vtf, err := f.VTileFeature(ctx, kmap, vmap, tile, simplify, !l.DontClip)
+		vtf, err := f.VTileFeature(ctx, kmap, vmap)
 		if err != nil {
 			switch err {
 			case context.Canceled:
 				return nil, err
 			default:
-				return nil, fmt.Errorf("Error getting VTileFeature: %v", err)
+				return nil, fmt.Errorf("error getting VTileFeature: %v", err)
 			}
 		}
+
 		if vtf != nil {
 			features = append(features, vtf)
 		}
 	}
-	ext := uint32(tile.Extent)
+
+	ext := uint32(l.Extent())
 	version := uint32(l.Version())
 	vtl := new(vectorTile.Tile_Layer)
 	vtl.Version = &version
@@ -109,10 +70,11 @@ func (l *Layer) VTileLayer(ctx context.Context, tile *tegola.Tile) (*vectorTile.
 	vtl.Keys = kmap
 	vtl.Values = valmap
 	vtl.Extent = &ext
+
 	return vtl, nil
 }
 
-//Version is the version of tile spec this layer is from.
+// Version is the version of tile spec this layer is from.
 func (*Layer) Version() int { return 2 }
 
 // Extent defaults to 4096

--- a/mvt/layer_test.go
+++ b/mvt/layer_test.go
@@ -7,19 +7,7 @@ import (
 	"github.com/go-spatial/tegola/basic"
 	"github.com/go-spatial/tegola/internal/p"
 	"github.com/go-spatial/tegola/mvt"
-	"github.com/go-spatial/tegola/mvt/vector_tile"
 )
-
-func newTileLayer(name string, keys []string, values []*vectorTile.Tile_Value, features []*vectorTile.Tile_Feature) *vectorTile.Tile_Layer {
-	return &vectorTile.Tile_Layer{
-		Version:  p.Uint32(mvt.Version),
-		Name:     &name,
-		Features: features,
-		Keys:     keys,
-		Values:   values,
-		Extent:   p.Uint32(mvt.DefaultExtent),
-	}
-}
 
 func TestLayerAddFeatures(t *testing.T) {
 	type tcase struct {

--- a/mvt/scale.go
+++ b/mvt/scale.go
@@ -1,0 +1,125 @@
+package mvt
+
+import (
+	"github.com/go-spatial/tegola"
+	"github.com/go-spatial/tegola/basic"
+	"github.com/go-spatial/tegola/internal/log"
+)
+
+// ScaleGeo converts the geometry's coordinates to tile coordinates
+func ScaleGeo(geo tegola.Geometry, tile *tegola.Tile) basic.Geometry {
+	switch g := geo.(type) {
+	case tegola.Point:
+		return scalept(g, tile)
+
+	case tegola.Point3:
+		return scalept(g, tile)
+
+	case tegola.MultiPoint:
+		pts := g.Points()
+		if len(pts) == 0 {
+			return nil
+		}
+		var ptmap = make(map[basic.Point]struct{})
+		var mp = make(basic.MultiPoint, 0, len(pts))
+		mp = append(mp, scalept(pts[0], tile))
+
+		ptmap[mp[0]] = struct{}{}
+		for i := 1; i < len(pts); i++ {
+
+			npt := scalept(pts[i], tile)
+			if _, ok := ptmap[npt]; ok {
+				// Skip duplicate points.
+				continue
+			}
+
+			ptmap[npt] = struct{}{}
+			mp = append(mp, npt)
+		}
+		return mp
+
+	case tegola.LineString:
+		return scalelinestr(g, tile)
+
+	case tegola.MultiLine:
+		var ml basic.MultiLine
+		for _, l := range g.Lines() {
+			nl := scalelinestr(l, tile)
+			if len(nl) > 0 {
+				ml = append(ml, nl)
+			}
+		}
+		return ml
+
+	case tegola.Polygon:
+		return scalePolygon(g, tile)
+
+	case tegola.MultiPolygon:
+		var mp basic.MultiPolygon
+		for _, p := range g.Polygons() {
+			np := scalePolygon(p, tile)
+			if len(np) > 0 {
+				mp = append(mp, np)
+			}
+		}
+		return mp
+	}
+
+	return basic.G{}
+}
+
+func scalept(g tegola.Point, tile *tegola.Tile) basic.Point {
+	pt, err := tile.ToPixel(tegola.WebMercator, [2]float64{g.X(), g.Y()})
+	if err != nil {
+		panic(err)
+	}
+	return basic.Point{pt[0], pt[1]}
+}
+
+func scalelinestr(g tegola.LineString, tile *tegola.Tile) (ls basic.Line) {
+	pts := g.Subpoints()
+	// If the linestring
+	if len(pts) < 2 {
+		// Not enought points to make a line.
+		return nil
+	}
+	ls = make(basic.Line, 0, len(pts))
+	ls = append(ls, scalept(pts[0], tile))
+	lidx := len(ls) - 1
+	for i := 1; i < len(pts); i++ {
+		npt := scalept(pts[i], tile)
+		if tegola.IsPointEqual(ls[lidx], npt) {
+			// drop any duplicate points.
+			continue
+		}
+		ls = append(ls, npt)
+		lidx = len(ls) - 1
+	}
+
+	if len(ls) < 2 {
+		// Not enough points. the zoom must be too far out for this ring.
+		return nil
+	}
+	return ls
+}
+
+func scalePolygon(g tegola.Polygon, tile *tegola.Tile) (p basic.Polygon) {
+	lines := g.Sublines()
+	p = make(basic.Polygon, 0, len(lines))
+
+	if len(lines) == 0 {
+		return p
+	}
+	for i := range lines {
+		ln := scalelinestr(lines[i], tile)
+		if len(ln) < 2 {
+			if debug {
+				// skip lines that have been reduced to less then 2 points.
+				log.Debug("skipping line 2", lines[i], len(ln))
+			}
+			continue
+		}
+		p = append(p, ln)
+	}
+	return p
+}

--- a/mvt/scale_internal_test.go
+++ b/mvt/scale_internal_test.go
@@ -1,0 +1,60 @@
+package mvt
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/go-spatial/tegola"
+	"github.com/go-spatial/tegola/basic"
+)
+
+func TestScaleLinestring(t *testing.T) {
+	tile := tegola.NewTile(20, 0, 0)
+
+	newLine := func(ptpairs ...float64) (ln basic.Line) {
+		for i, j := 0, 1; j < len(ptpairs); i, j = i+2, j+2 {
+			pt, err := tile.FromPixel(tegola.WebMercator, [2]float64{ptpairs[i], ptpairs[j]})
+			if err != nil {
+				panic(fmt.Sprintf("error trying to convert %v,%v to WebMercator. %v", ptpairs[i], ptpairs[j], err))
+			}
+
+			ln = append(ln, basic.Point(pt))
+		}
+
+		return ln
+	}
+
+	type tcase struct {
+		g tegola.LineString
+		e basic.Line
+	}
+
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			got := scalelinestr(tc.g, tile)
+
+			if !reflect.DeepEqual(tc.e, got) {
+				t.Errorf("expected %v got %v", tc.e, got)
+			}
+		}
+	}
+
+	tests := map[string]tcase{
+		"duplicate pt simple line": {
+			g: basic.NewLine(9.0, 9.0, 9.0, 9.0),
+		},
+		"simple line": {
+			g: newLine(10.0, 10.0, 11.0, 11.0),
+			e: basic.NewLine(9.0, 9.0, 11.0, 11.0),
+		},
+		"simple line 3pt": {
+			g: newLine(10.0, 10.0, 11.0, 10.0, 11.0, 15.0),
+			e: basic.NewLine(9.0, 9.0, 11.0, 9.0, 11.0, 14.0),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, fn(tc))
+	}
+}

--- a/mvt/tile.go
+++ b/mvt/tile.go
@@ -1,20 +1,18 @@
 package mvt
 
 import (
+	"context"
 	"fmt"
 
-	"context"
-
-	"github.com/go-spatial/tegola"
-	"github.com/go-spatial/tegola/mvt/vector_tile"
+	vectorTile "github.com/go-spatial/tegola/mvt/vector_tile"
 )
 
-//Tile describes a tile.
+// Tile describes a Mapbox Vector Tile
 type Tile struct {
 	layers []Layer
 }
 
-//AddLayers adds a Layer to the tile
+// AddLayers adds a Layer to the Tile
 func (t *Tile) AddLayers(layers ...*Layer) error {
 	// Need to make sure that all layer names are unique.
 	for i := range layers {
@@ -25,7 +23,7 @@ func (t *Tile) AddLayers(layers ...*Layer) error {
 		}
 		for i, l := range t.layers {
 			if l.Name == nl.Name {
-				return fmt.Errorf("Layer %v, already is named %v, new layer not added.", i, l.Name)
+				return fmt.Errorf("layer %v, already is named %v, new layer not added.", i, l.Name)
 			}
 		}
 		t.layers = append(t.layers, *nl)
@@ -39,21 +37,24 @@ func (t *Tile) Layers() (l []Layer) {
 	return l
 }
 
-//VTile returns a tile object according to the Google Protobuff def. This function
-// does the hard work of converting everything to the standard.
-func (t *Tile) VTile(ctx context.Context, tile *tegola.Tile) (vt *vectorTile.Tile, err error) {
+// VTile returns a Tile according to the Google Protobuff definition.
+// This function does the hard work of converting everything to the standard.
+func (t *Tile) VTile(ctx context.Context) (vt *vectorTile.Tile, err error) {
 	vt = new(vectorTile.Tile)
+
 	for _, l := range t.layers {
-		vtl, err := l.VTileLayer(ctx, tile)
+		vtl, err := l.VTileLayer(ctx)
 		if err != nil {
 			switch err {
 			case context.Canceled:
 				return nil, err
 			default:
-				return nil, fmt.Errorf("Error Getting VTileLayer: %v", err)
+				return nil, fmt.Errorf("error Getting VTileLayer: %v", err)
 			}
 		}
+
 		vt.Layers = append(vt.Layers, vtl)
 	}
+
 	return vt, nil
 }


### PR DESCRIPTION
The mvt encoding package contained core geo processing routines
(i.e. simplification, make valid, scaling). These routines have
been carved out of the mvt pacakge and moved into the atlas
map Encode() step. This allows the mvt package to focus entirely
on encoding.

This is a transitional step which positions tegola to adopt the
new make valid routine which is currently under development in the
geom package. This transition also positions tegola to adopt the
new simplification routine which is in the geom package. The mvt
package will soon be carved out of tegola and also moved to the
geom package.

During the refactor, a fair amount of code was purged from the mvt
package and many function signatures were able to reduce the number
of parameters they required. Additionally the mvt feature
encoding tests were able to fixed to match the specifications
supplied tests and previously breaking tests are now passing.

closes #224