### PR TITLE
skip initialization of config in version and help commands

### DIFF
--- a/cmd/tegola/cmd/root.go
+++ b/cmd/tegola/cmd/root.go
@@ -49,8 +49,12 @@ Version: %v`, Version),
 
 func rootCmdValidatePersistent(cmd *cobra.Command, args []string) (err error) {
 	requireCache := RequireCache || cachecmd.RequireCache
-
-	return initConfig(configFile, requireCache)
+	switch cmd.CalledAs() {
+	case "help", "version":
+		return nil
+	default:
+		return initConfig(configFile, requireCache)
+	}
 }
 
 func initConfig(configFile string, cacheRequired bool) (err error) {


### PR DESCRIPTION
I changed the `rootCmdValidatePersistent` function to check command names and skip the config init function. Now, `version` and `help` can be run cleanly without a config file.