### PR TITLE
remove basic types from mvt package

### DIFF
--- a/mvt/debug.go
+++ b/mvt/debug.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"log"
 
 	"github.com/go-spatial/tegola"
 	"github.com/go-spatial/tegola/basic"
 	"github.com/go-spatial/tegola/internal/convert"
-	"github.com/go-spatial/tegola/internal/log"
 	"github.com/go-spatial/tegola/maths"
 )
 
@@ -29,19 +29,19 @@ func createDebugFile(min, max maths.Pt, geo tegola.Geometry, err error) {
 
 	geo, err = basic.CloneGeometry(geo)
 	if err != nil {
-		log.Errorf("failed to clone geo for test case. %v", err)
+		log.Printf("failed to clone geo for test case. %v", err)
 		return
 	}
 
 	bgeo, err := convert.ToTegola(geo)
 	if err != nil {
-		log.Errorf("failed to convert geo for test case. %v", err)
+		log.Printf("failed to convert geo for test case. %v", err)
 		return
 	}
 
 	f, err := os.Create(filename)
 	if err != nil {
-		log.Errorf("failed to create test file %v : %v.", filename, err)
+		log.Printf("failed to create test file %v : %v.", filename, err)
 		return
 	}
 	defer f.Close()
@@ -53,9 +53,9 @@ func createDebugFile(min, max maths.Pt, geo tegola.Geometry, err error) {
 	}
 
 	if err = json.NewEncoder(f).Encode(geodebug); err != nil {
-		log.Errorf("err encoding json: %v", err)
+		log.Printf("err encoding json: %v", err)
 		return
 	}
 
-	log.Infof("created file: %v", filename)
+	log.Printf("created file: %v", filename)
 }

--- a/mvt/feature.go
+++ b/mvt/feature.go
@@ -3,10 +3,10 @@ package mvt
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/go-spatial/geom"
 	"github.com/go-spatial/geom/encoding/wkt"
-	"github.com/go-spatial/tegola/internal/log"
 	vectorTile "github.com/go-spatial/tegola/mvt/vector_tile"
 )
 
@@ -500,7 +500,7 @@ func keyvalTagsMap(keyMap []string, valueMap []interface{}, f *Feature) (tags []
 		}
 
 		if kidx == -1 {
-			log.Errorf("did not find key (%v) in keymap.", key)
+			log.Printf("did not find key (%v) in keymap.", key)
 			return tags, fmt.Errorf("did not find key (%v) in keymap.", key)
 		}
 

--- a/mvt/feature_internal_test.go
+++ b/mvt/feature_internal_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-spatial/tegola/basic"
+	"github.com/go-spatial/geom"
 	vectorTile "github.com/go-spatial/tegola/mvt/vector_tile"
 )
 
 func TestEncodeGeometry(t *testing.T) {
 	type tcase struct {
-		geo          basic.Geometry
+		geo          geom.Geometry
 		geomType     vectorTile.Tile_GeomType
 		expectedGeom []uint32
 		expectedErr  error
@@ -50,80 +50,80 @@ func TestEncodeGeometry(t *testing.T) {
 			expectedErr:  ErrNilGeometryType,
 		},
 		"point 1": tcase{
-			geo:          basic.Point{1, 1},
+			geo:          geom.Point{1, 1},
 			geomType:     vectorTile.Tile_POINT,
 			expectedGeom: []uint32{9, 2, 2},
 		},
 		"point 2": tcase{
-			geo:          basic.Point{25, 17},
+			geo:          geom.Point{25, 17},
 			geomType:     vectorTile.Tile_POINT,
 			expectedGeom: []uint32{9, 50, 34},
 		},
 		"multi point": tcase{
-			geo: basic.MultiPoint{
-				basic.Point{5, 7},
-				basic.Point{3, 2},
+			geo: geom.MultiPoint{
+				geom.Point{5, 7},
+				geom.Point{3, 2},
 			},
 			geomType:     vectorTile.Tile_POINT,
 			expectedGeom: []uint32{17, 10, 14, 3, 9},
 		},
 		"linestring": tcase{
-			geo: basic.Line{
-				basic.Point{2, 2},
-				basic.Point{2, 10},
-				basic.Point{10, 10},
+			geo: geom.LineString{
+				geom.Point{2, 2},
+				geom.Point{2, 10},
+				geom.Point{10, 10},
 			},
 			geomType:     vectorTile.Tile_LINESTRING,
 			expectedGeom: []uint32{9, 4, 4, 18, 0, 16, 16, 0},
 		},
 		"multi linestring": tcase{
-			geo: basic.MultiLine{
-				basic.Line{
-					basic.Point{2, 2},
-					basic.Point{2, 10},
-					basic.Point{10, 10},
+			geo: geom.MultiLineString{
+				geom.LineString{
+					geom.Point{2, 2},
+					geom.Point{2, 10},
+					geom.Point{10, 10},
 				},
-				basic.Line{
-					basic.Point{1, 1},
-					basic.Point{3, 5},
+				geom.LineString{
+					geom.Point{1, 1},
+					geom.Point{3, 5},
 				},
 			},
 			geomType:     vectorTile.Tile_LINESTRING,
 			expectedGeom: []uint32{9, 4, 4, 18, 0, 16, 16, 0, 9, 17, 17, 10, 4, 8},
 		},
 		"polygon": tcase{
-			geo: basic.Polygon{
-				basic.Line{
-					basic.Point{3, 6},
-					basic.Point{8, 12},
-					basic.Point{20, 34},
+			geo: geom.Polygon{
+				geom.LineString{
+					geom.Point{3, 6},
+					geom.Point{8, 12},
+					geom.Point{20, 34},
 				},
 			},
 			geomType:     vectorTile.Tile_POLYGON,
 			expectedGeom: []uint32{9, 6, 12, 18, 10, 12, 24, 44, 15},
 		},
 		"multi polygon": tcase{
-			geo: basic.MultiPolygon{
-				basic.Polygon{
-					basic.Line{
-						basic.Point{0, 0},
-						basic.Point{10, 0},
-						basic.Point{10, 10},
-						basic.Point{0, 10},
+			geo: geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{
+						geom.Point{0, 0},
+						geom.Point{10, 0},
+						geom.Point{10, 10},
+						geom.Point{0, 10},
 					},
 				},
-				basic.Polygon{
-					basic.Line{
-						basic.Point{11, 11},
-						basic.Point{20, 11},
-						basic.Point{20, 20},
-						basic.Point{11, 20},
+				geom.Polygon{
+					geom.LineString{
+						geom.Point{11, 11},
+						geom.Point{20, 11},
+						geom.Point{20, 20},
+						geom.Point{11, 20},
 					},
-					basic.Line{
-						basic.Point{13, 13},
-						basic.Point{13, 17},
-						basic.Point{17, 17},
-						basic.Point{17, 13},
+					geom.LineString{
+						geom.Point{13, 13},
+						geom.Point{13, 17},
+						geom.Point{17, 17},
+						geom.Point{17, 13},
 					},
 				},
 			},

--- a/mvt/layer_internal_test.go
+++ b/mvt/layer_internal_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-spatial/tegola/basic"
+	"github.com/go-spatial/geom"
 	"github.com/go-spatial/tegola/internal/p"
 	vectorTile "github.com/go-spatial/tegola/mvt/vector_tile"
 )
@@ -73,7 +73,7 @@ func TestLayer(t *testing.T) {
 				Name: "onefeature",
 				features: []Feature{
 					{
-						Geometry: basic.Point{1, 1},
+						Geometry: geom.Point{1, 1},
 						Tags: map[string]interface{}{
 							"tag1": "tag",
 							"tag2": "tag",
@@ -97,11 +97,11 @@ func TestLayer(t *testing.T) {
 				Name: "twofeatures",
 				features: []Feature{
 					{
-						Geometry: &basic.Polygon{
-							basic.Line{
-								basic.Point{3, 6},
-								basic.Point{8, 12},
-								basic.Point{20, 34},
+						Geometry: geom.Polygon{
+							geom.LineString{
+								geom.Point{3, 6},
+								geom.Point{8, 12},
+								geom.Point{20, 34},
 							},
 						},
 						Tags: map[string]interface{}{
@@ -110,7 +110,7 @@ func TestLayer(t *testing.T) {
 						},
 					},
 					{
-						Geometry: basic.Point{1, 1},
+						Geometry: geom.Point{1, 1},
 						Tags: map[string]interface{}{
 							"tag1": "tag",
 							"tag2": "tag",

--- a/mvt/layer_test.go
+++ b/mvt/layer_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-spatial/tegola/basic"
+	"github.com/go-spatial/geom"
 	"github.com/go-spatial/tegola/internal/p"
 	"github.com/go-spatial/tegola/mvt"
 )
@@ -51,12 +51,12 @@ func TestLayerAddFeatures(t *testing.T) {
 			features: []mvt.Feature{
 				{
 					Tags:     map[string]interface{}{"btag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
+					Geometry: geom.Point{12.0, 15.0},
 				},
 				{
 					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
+					Geometry: geom.Point{12.0, 15.0},
 				},
 			},
 		},
@@ -65,11 +65,11 @@ func TestLayerAddFeatures(t *testing.T) {
 				{
 					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
+					Geometry: geom.Point{12.0, 15.0},
 				},
 				{
 					Tags:     map[string]interface{}{"btag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
+					Geometry: geom.Point{12.0, 15.0},
 				},
 			},
 		},
@@ -78,24 +78,24 @@ func TestLayerAddFeatures(t *testing.T) {
 				{
 					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
+					Geometry: geom.Point{12.0, 15.0},
 				},
 				{
 					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
+					Geometry: geom.Point{12.0, 15.0},
 				},
 			},
 			expected: []mvt.Feature{
 				{
 					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
+					Geometry: geom.Point{12.0, 15.0},
 				},
 				{
 					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
+					Geometry: geom.Point{12.0, 15.0},
 				},
 			},
 		},
@@ -104,12 +104,12 @@ func TestLayerAddFeatures(t *testing.T) {
 				{
 					ID:       p.Uint64(1),
 					Tags:     map[string]interface{}{"atag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
+					Geometry: geom.Point{12.0, 15.0},
 				},
 				{
 					ID:       p.Uint64(2),
 					Tags:     map[string]interface{}{"atag": "tag"},
-					Geometry: basic.Point{12.0, 15.0},
+					Geometry: geom.Point{12.0, 15.0},
 				},
 			},
 		},

--- a/mvt/scale.go
+++ b/mvt/scale.go
@@ -1,10 +1,11 @@
 package mvt
 
 import (
+	"log"
+
 	"github.com/go-spatial/geom"
 	"github.com/go-spatial/geom/cmp"
 	"github.com/go-spatial/tegola"
-	"github.com/go-spatial/tegola/internal/log"
 )
 
 // ScaleGeo converts the geometry's coordinates to tile coordinates
@@ -120,7 +121,7 @@ func scalePolygon(g geom.Polygon, tile *tegola.Tile) (p geom.Polygon) {
 		if len(ln) < 2 {
 			if debug {
 				// skip lines that have been reduced to less then 2 points.
-				log.Debug("skipping line 2", line, len(ln))
+				log.Println("skipping line 2", line, len(ln))
 			}
 			continue
 		}

--- a/mvt/scale.go
+++ b/mvt/scale.go
@@ -1,28 +1,32 @@
 package mvt
 
 import (
+	"github.com/go-spatial/geom"
+	"github.com/go-spatial/geom/cmp"
 	"github.com/go-spatial/tegola"
-	"github.com/go-spatial/tegola/basic"
 	"github.com/go-spatial/tegola/internal/log"
 )
 
 // ScaleGeo converts the geometry's coordinates to tile coordinates
-func ScaleGeo(geo tegola.Geometry, tile *tegola.Tile) basic.Geometry {
+func ScaleGeo(geo tegola.Geometry, tile *tegola.Tile) geom.Geometry {
 	switch g := geo.(type) {
-	case tegola.Point:
+	case geom.Point:
 		return scalept(g, tile)
 
-	case tegola.Point3:
-		return scalept(g, tile)
-
-	case tegola.MultiPoint:
+	case geom.MultiPoint:
 		pts := g.Points()
 		if len(pts) == 0 {
 			return nil
 		}
-		var ptmap = make(map[basic.Point]struct{})
-		var mp = make(basic.MultiPoint, 0, len(pts))
-		mp = append(mp, scalept(pts[0], tile))
+
+		// TODO the ptmap is used for removing duplicate points.
+		// This does not seem to be part of the spec, but it seems
+		// helpful for reducing the point count, especially with
+		// very zoomed out geometries. Further discussion should be had...
+		// https://github.com/mapbox/vector-tile-spec/tree/master/2.1#4342-point-geometry-type
+		var ptmap = make(map[geom.Point]struct{})
+		var mp = make(geom.MultiPoint, 1, len(pts))
+		mp[0] = scalept(pts[0], tile)
 
 		ptmap[mp[0]] = struct{}{}
 		for i := 1; i < len(pts); i++ {
@@ -38,12 +42,12 @@ func ScaleGeo(geo tegola.Geometry, tile *tegola.Tile) basic.Geometry {
 		}
 		return mp
 
-	case tegola.LineString:
+	case geom.LineString:
 		return scalelinestr(g, tile)
 
-	case tegola.MultiLine:
-		var ml basic.MultiLine
-		for _, l := range g.Lines() {
+	case geom.MultiLineString:
+		var ml geom.MultiLineString
+		for _, l := range g.LineStrings() {
 			nl := scalelinestr(l, tile)
 			if len(nl) > 0 {
 				ml = append(ml, nl)
@@ -51,11 +55,11 @@ func ScaleGeo(geo tegola.Geometry, tile *tegola.Tile) basic.Geometry {
 		}
 		return ml
 
-	case tegola.Polygon:
+	case geom.Polygon:
 		return scalePolygon(g, tile)
 
-	case tegola.MultiPolygon:
-		var mp basic.MultiPolygon
+	case geom.MultiPolygon:
+		var mp geom.MultiPolygon
 		for _, p := range g.Polygons() {
 			np := scalePolygon(p, tile)
 			if len(np) > 0 {
@@ -65,30 +69,30 @@ func ScaleGeo(geo tegola.Geometry, tile *tegola.Tile) basic.Geometry {
 		return mp
 	}
 
-	return basic.G{}
+	return nil
 }
 
-func scalept(g tegola.Point, tile *tegola.Tile) basic.Point {
-	pt, err := tile.ToPixel(tegola.WebMercator, [2]float64{g.X(), g.Y()})
+func scalept(g geom.Point, tile *tegola.Tile) geom.Point {
+	pt, err := tile.ToPixel(tegola.WebMercator, g)
 	if err != nil {
 		panic(err)
 	}
-	return basic.Point{pt[0], pt[1]}
+	return geom.Point(pt)
 }
 
-func scalelinestr(g tegola.LineString, tile *tegola.Tile) (ls basic.Line) {
-	pts := g.Subpoints()
+func scalelinestr(g geom.LineString, tile *tegola.Tile) (ls geom.LineString) {
+	pts := g
 	// If the linestring
 	if len(pts) < 2 {
 		// Not enought points to make a line.
 		return nil
 	}
-	ls = make(basic.Line, 0, len(pts))
+	ls = make(geom.LineString, 0, len(pts))
 	ls = append(ls, scalept(pts[0], tile))
 	lidx := len(ls) - 1
 	for i := 1; i < len(pts); i++ {
 		npt := scalept(pts[i], tile)
-		if tegola.IsPointEqual(ls[lidx], npt) {
+		if cmp.PointEqual(ls[lidx], npt) {
 			// drop any duplicate points.
 			continue
 		}
@@ -103,19 +107,20 @@ func scalelinestr(g tegola.LineString, tile *tegola.Tile) (ls basic.Line) {
 	return ls
 }
 
-func scalePolygon(g tegola.Polygon, tile *tegola.Tile) (p basic.Polygon) {
-	lines := g.Sublines()
-	p = make(basic.Polygon, 0, len(lines))
+func scalePolygon(g geom.Polygon, tile *tegola.Tile) (p geom.Polygon) {
+	lines := geom.MultiLineString(g.LinearRings())
+	p = make(geom.Polygon, 0, len(lines))
 
 	if len(lines) == 0 {
 		return p
 	}
-	for i := range lines {
-		ln := scalelinestr(lines[i], tile)
+
+	for _, line := range lines.LineStrings() {
+		ln := scalelinestr(line, tile)
 		if len(ln) < 2 {
 			if debug {
 				// skip lines that have been reduced to less then 2 points.
-				log.Debug("skipping line 2", lines[i], len(ln))
+				log.Debug("skipping line 2", line, len(ln))
 			}
 			continue
 		}

--- a/mvt/scale_internal_test.go
+++ b/mvt/scale_internal_test.go
@@ -5,29 +5,29 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-spatial/geom"
 	"github.com/go-spatial/tegola"
-	"github.com/go-spatial/tegola/basic"
 )
 
 func TestScaleLinestring(t *testing.T) {
 	tile := tegola.NewTile(20, 0, 0)
 
-	newLine := func(ptpairs ...float64) (ln basic.Line) {
+	newLine := func(ptpairs ...float64) (ln geom.LineString) {
 		for i, j := 0, 1; j < len(ptpairs); i, j = i+2, j+2 {
 			pt, err := tile.FromPixel(tegola.WebMercator, [2]float64{ptpairs[i], ptpairs[j]})
 			if err != nil {
 				panic(fmt.Sprintf("error trying to convert %v,%v to WebMercator. %v", ptpairs[i], ptpairs[j], err))
 			}
 
-			ln = append(ln, basic.Point(pt))
+			ln = append(ln, geom.Point(pt))
 		}
 
 		return ln
 	}
 
 	type tcase struct {
-		g tegola.LineString
-		e basic.Line
+		g geom.LineString
+		e geom.LineString
 	}
 
 	fn := func(tc tcase) func(t *testing.T) {
@@ -42,15 +42,15 @@ func TestScaleLinestring(t *testing.T) {
 
 	tests := map[string]tcase{
 		"duplicate pt simple line": {
-			g: basic.NewLine(9.0, 9.0, 9.0, 9.0),
+			g: geom.LineString{{9.0, 9.0}, {9.0, 9.0}},
 		},
 		"simple line": {
 			g: newLine(10.0, 10.0, 11.0, 11.0),
-			e: basic.NewLine(9.0, 9.0, 11.0, 11.0),
+			e: geom.LineString{{9.0, 9.0}, {11.0, 11.0}},
 		},
 		"simple line 3pt": {
 			g: newLine(10.0, 10.0, 11.0, 10.0, 11.0, 15.0),
-			e: basic.NewLine(9.0, 9.0, 11.0, 9.0, 11.0, 14.0),
+			e: geom.LineString{{9.0, 9.0}, {11.0, 9.0}, {11.0, 14.0}},
 		},
 	}
 


### PR DESCRIPTION
See more on #628 

There is a file, `mvt/debug.go` that still uses `basic` types, I'm not sure if it should be kept; please advise.