### PR TITLE
[DOC] Added go get command to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The requested tile will be encode a layer with the `name` value set to `debug` a
 Tegola is written in [Go](https://golang.org/) and requires Go 1.8+ to compile from source. To build tegola from source, make sure you have Go installed and have cloned the repository to your `$GOPATH`. Navigate to the repository then run the following commands:
 
 ```bash
+go get -d ./...
 cd cmd/tegola/
 go build
 ```


### PR DESCRIPTION
Added `go get -d ./...` to the Building From Source section to install required dependencies to build tegola.