### PR TITLE
Added configurable webserver URI Prefix to

### DIFF
--- a/cmd/tegola/cmd/server.go
+++ b/cmd/tegola/cmd/server.go
@@ -50,6 +50,10 @@ var serverCmd = &cobra.Command{
 			server.Headers[name] = val
 		}
 
+		if conf.Webserver.URIPrefix != "" {
+			server.URIPrefix = string(conf.Webserver.URIPrefix)
+		}
+
 		// start our webserver
 		srv := server.Start(nil, serverPort)
 		shutdown(srv)

--- a/cmd/tegola_lambda/main.go
+++ b/cmd/tegola_lambda/main.go
@@ -93,6 +93,10 @@ func main() {
 		server.Headers[name] = val
 	}
 
+	if conf.Webserver.URIPrefix != "" {
+		server.URIPrefix = string(conf.Webserver.URIPrefix)
+	}
+
 	// http route setup
 	mux := server.NewRouter(nil)
 
@@ -105,7 +109,7 @@ func main() {
 
 // URLRoot overrides the default server.URLRoot function in order to include the "stage" part of the root
 // that is part of lambda's URL scheme
-func URLRoot(r *http.Request) string {
+func URLRoot(r *http.Request) *url.URL {
 	u := url.URL{
 		Scheme: scheme(r),
 		Host:   r.Header.Get("Host"),
@@ -116,7 +120,7 @@ func URLRoot(r *http.Request) string {
 		u.Path = ctx.RequestContext.Stage
 	}
 
-	return u.String()
+	return &u
 }
 
 // various checks to determine if the request is http or https. the scheme is needed for the TileJSON URLs

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,4 @@
-/*
-	config loads and understands the tegola config format.
-*/
+// Package config loads and understands the tegola config format.
 package config
 
 import (
@@ -35,9 +33,10 @@ type Config struct {
 }
 
 type Webserver struct {
-	HostName env.String `toml:"hostname"`
-	Port     env.String `toml:"port"`
-	Headers  env.Dict   `toml:"headers"`
+	HostName  env.String `toml:"hostname"`
+	Port      env.String `toml:"port"`
+	URIPrefix env.String `toml:"uri_prefix"`
+	Headers   env.Dict   `toml:"headers"`
 }
 
 // A Map represents a map in the Tegola Config file.
@@ -137,6 +136,15 @@ func (c *Config) Validate() error {
 			if v == strings.ToLower(k) {
 				return ErrInvalidHeader{Header: k}
 			}
+		}
+	}
+
+	// check if webserver.uri_prefix is set and if so
+	// confirm it starts with a forward slash "/"
+	if string(c.Webserver.URIPrefix) != "" {
+		uriPrefix := string(c.Webserver.URIPrefix)
+		if string(uriPrefix[0]) != "/" {
+			return ErrInvalidURIPrefix(uriPrefix)
 		}
 	}
 

--- a/config/errors.go
+++ b/config/errors.go
@@ -60,3 +60,9 @@ type ErrInvalidHeader struct {
 func (e ErrInvalidHeader) Error() string {
 	return fmt.Sprintf("config: header (%v) blacklisted", e.Header)
 }
+
+type ErrInvalidURIPrefix string
+
+func (e ErrInvalidURIPrefix) Error() string {
+	return fmt.Sprintf("config: invalid uri_prefix (%v). uri_prefix must start with a forward slash '/' ", string(e))
+}

--- a/server/README.md
+++ b/server/README.md
@@ -14,6 +14,7 @@ Access-Control-Allow-Origin = "*"
 
 - `port` (string): [Optional] Port and bind string. For example ":9090" or "127.0.0.1:9090". Defaults to ":8080"
 - `hostname` (string): [Optional] The hostname to use in the various JSON endpoints. This is useful if tegola is behind a proxy and can't read the API consumer's request host directly.
+- `uri_prefix` (string): [Optional] A prefix to add to all API routes. This is useful when tegola is behind a proxy (i.e. example.com/tegola). The prexfix will be added to all URLs included in the capabilities endpoint responses. 
 
 ## Local development of the embedded viewer
 

--- a/server/handle_capabilities.go
+++ b/server/handle_capabilities.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path"
 
 	"github.com/go-spatial/geom"
 	"github.com/go-spatial/tegola/atlas"
@@ -61,9 +62,9 @@ func (req HandleCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			Bounds:      m.Bounds,
 			Center:      m.Center,
 			Tiles: []string{
-				fmt.Sprintf("%v/maps/%v/{z}/{x}/{y}.pbf%v", URLRoot(r), m.Name, debugQuery),
+				fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, "maps", m.Name, "{z}/{x}/{y}.pbf"), debugQuery),
 			},
-			Capabilities: fmt.Sprintf("%v/capabilities/%v.json%v", URLRoot(r), m.Name, debugQuery),
+			Capabilities: fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, "capabilities", m.Name+".json"), debugQuery),
 		}
 
 		for i := range m.Layers {
@@ -94,7 +95,7 @@ func (req HandleCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			cLayer := CapabilitiesLayer{
 				Name: m.Layers[i].MVTName(),
 				Tiles: []string{
-					fmt.Sprintf("%v/maps/%v/%v/{z}/{x}/{y}.pbf%v", URLRoot(r), m.Name, m.Layers[i].MVTName(), debugQuery),
+					fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, "maps", m.Name, m.Layers[i].MVTName(), "{z}/{x}/{y}.pbf"), debugQuery),
 				},
 				MinZoom: m.Layers[i].MinZoom,
 				MaxZoom: m.Layers[i].MaxZoom,

--- a/server/handle_capabilities.go
+++ b/server/handle_capabilities.go
@@ -2,9 +2,8 @@ package server
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"path"
+	"net/url"
 
 	"github.com/go-spatial/geom"
 	"github.com/go-spatial/tegola/atlas"
@@ -45,11 +44,11 @@ func (req HandleCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	// iterate our registered maps
 	for _, m := range atlas.AllMaps() {
-		var debugQuery string
+		debugQuery := url.Values{}
 
 		// if we have a debug param add it to our URLs
 		if query.Get("debug") == "true" {
-			debugQuery = "?debug=true"
+			debugQuery.Set("debug", "true")
 
 			// update our map to include the debug layers
 			m = m.AddDebugLayers()
@@ -62,9 +61,9 @@ func (req HandleCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			Bounds:      m.Bounds,
 			Center:      m.Center,
 			Tiles: []string{
-				fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, "maps", m.Name, "{z}/{x}/{y}.pbf"), debugQuery),
+				buildCapabilitiesURL(r, []string{"maps", m.Name, "{z}/{x}/{y}.pbf"}, debugQuery),
 			},
-			Capabilities: fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, "capabilities", m.Name+".json"), debugQuery),
+			Capabilities: buildCapabilitiesURL(r, []string{"capabilities", m.Name + ".json"}, debugQuery),
 		}
 
 		for i := range m.Layers {
@@ -95,7 +94,7 @@ func (req HandleCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			cLayer := CapabilitiesLayer{
 				Name: m.Layers[i].MVTName(),
 				Tiles: []string{
-					fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, "maps", m.Name, m.Layers[i].MVTName(), "{z}/{x}/{y}.pbf"), debugQuery),
+					buildCapabilitiesURL(r, []string{"maps", m.Name, m.Layers[i].MVTName(), "{z}/{x}/{y}.pbf"}, debugQuery),
 				},
 				MinZoom: m.Layers[i].MinZoom,
 				MaxZoom: m.Layers[i].MaxZoom,

--- a/server/handle_capabilities_test.go
+++ b/server/handle_capabilities_test.go
@@ -246,61 +246,6 @@ func TestHandleCapabilities(t *testing.T) {
 				},
 			},
 		},
-		"config set hostname unset port": {
-			// With hostname set and port unset in config, urls should have host from config and
-			//  port from uri: "cdn.tegola.io:8080"
-			hostname: "cdn.tegola.io",
-			uri:      "http://localhost:8080/capabilities?debug=true",
-			expected: server.Capabilities{
-				Version: serverVersion,
-				Maps: []server.CapabilitiesMap{
-					{
-						Name:         "test-map",
-						Attribution:  "test attribution",
-						Center:       [3]float64{1.0, 2.0, 3.0},
-						Bounds:       tegola.WGS84Bounds,
-						Capabilities: "http://cdn.tegola.io:8080/capabilities/test-map.json?debug=true",
-						Tiles: []string{
-							"http://cdn.tegola.io:8080/maps/test-map/{z}/{x}/{y}.pbf?debug=true",
-						},
-						Layers: []server.CapabilitiesLayer{
-							{
-								Name: testLayer1.MVTName(),
-								Tiles: []string{
-									fmt.Sprintf("http://cdn.tegola.io:8080/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer1.MVTName()),
-								},
-								MinZoom: testLayer1.MinZoom,
-								MaxZoom: testLayer3.MaxZoom, // layer 1 and layer 3 share a name in our test so the zoom range includes the entire zoom range
-							},
-							{
-								Name: "test-layer-2-name",
-								Tiles: []string{
-									fmt.Sprintf("http://cdn.tegola.io:8080/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer2.MVTName()),
-								},
-								MinZoom: testLayer2.MinZoom,
-								MaxZoom: testLayer2.MaxZoom,
-							},
-							{
-								Name: "debug-tile-outline",
-								Tiles: []string{
-									"http://cdn.tegola.io:8080/maps/test-map/debug-tile-outline/{z}/{x}/{y}.pbf?debug=true",
-								},
-								MinZoom: 0,
-								MaxZoom: atlas.MaxZoom,
-							},
-							{
-								Name: "debug-tile-center",
-								Tiles: []string{
-									"http://cdn.tegola.io:8080/maps/test-map/debug-tile-center/{z}/{x}/{y}.pbf?debug=true",
-								},
-								MinZoom: 0,
-								MaxZoom: atlas.MaxZoom,
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 
 	for name, tc := range tests {

--- a/server/handle_capabilities_test.go
+++ b/server/handle_capabilities_test.go
@@ -246,6 +246,61 @@ func TestHandleCapabilities(t *testing.T) {
 				},
 			},
 		},
+		"config set hostname unset port": {
+			// With hostname set and port unset in config, urls should have host from config and
+			//  port from uri: "cdn.tegola.io:8080"
+			hostname: "cdn.tegola.io",
+			uri:      "http://localhost:8080/capabilities?debug=true",
+			expected: server.Capabilities{
+				Version: serverVersion,
+				Maps: []server.CapabilitiesMap{
+					{
+						Name:         "test-map",
+						Attribution:  "test attribution",
+						Center:       [3]float64{1.0, 2.0, 3.0},
+						Bounds:       tegola.WGS84Bounds,
+						Capabilities: "http://cdn.tegola.io/capabilities/test-map.json?debug=true",
+						Tiles: []string{
+							"http://cdn.tegola.io/maps/test-map/{z}/{x}/{y}.pbf?debug=true",
+						},
+						Layers: []server.CapabilitiesLayer{
+							{
+								Name: testLayer1.MVTName(),
+								Tiles: []string{
+									fmt.Sprintf("http://cdn.tegola.io/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer1.MVTName()),
+								},
+								MinZoom: testLayer1.MinZoom,
+								MaxZoom: testLayer3.MaxZoom, // layer 1 and layer 3 share a name in our test so the zoom range includes the entire zoom range
+							},
+							{
+								Name: "test-layer-2-name",
+								Tiles: []string{
+									fmt.Sprintf("http://cdn.tegola.io/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer2.MVTName()),
+								},
+								MinZoom: testLayer2.MinZoom,
+								MaxZoom: testLayer2.MaxZoom,
+							},
+							{
+								Name: "debug-tile-outline",
+								Tiles: []string{
+									"http://cdn.tegola.io/maps/test-map/debug-tile-outline/{z}/{x}/{y}.pbf?debug=true",
+								},
+								MinZoom: 0,
+								MaxZoom: atlas.MaxZoom,
+							},
+							{
+								Name: "debug-tile-center",
+								Tiles: []string{
+									"http://cdn.tegola.io/maps/test-map/debug-tile-center/{z}/{x}/{y}.pbf?debug=true",
+								},
+								MinZoom: 0,
+								MaxZoom: atlas.MaxZoom,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/server/handle_map_capabilities.go
+++ b/server/handle_map_capabilities.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"path"
 	"strings"
 
 	"github.com/dimfeld/httptreemux"
@@ -125,7 +126,7 @@ func (req HandleMapCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Reques
 			MinZoom: m.Layers[i].MinZoom,
 			MaxZoom: m.Layers[i].MaxZoom,
 			Tiles: []string{
-				fmt.Sprintf("%v/maps/%v/%v/{z}/{x}/{y}.pbf%v", URLRoot(r), req.mapName, m.Layers[i].MVTName(), debugQuery),
+				fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, "maps", req.mapName, m.Layers[i].MVTName(), "{z}/{x}/{y}.pbf"), debugQuery),
 			},
 		}
 
@@ -145,7 +146,7 @@ func (req HandleMapCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		tileJSON.VectorLayers = append(tileJSON.VectorLayers, layer)
 	}
 
-	tileURL := fmt.Sprintf("%v/maps/%v/{z}/{x}/{y}.pbf%v", URLRoot(r), req.mapName, debugQuery)
+	tileURL := fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, "maps", req.mapName, "{z}/{x}/{y}.pbf"), debugQuery)
 
 	// build our URL scheme for the tile grid
 	tileJSON.Tiles = append(tileJSON.Tiles, tileURL)

--- a/server/handle_map_capabilities.go
+++ b/server/handle_map_capabilities.go
@@ -2,10 +2,9 @@ package server
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
-	"path"
+	"net/url"
 	"strings"
 
 	"github.com/dimfeld/httptreemux"
@@ -67,10 +66,10 @@ func (req HandleMapCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	// parse our query string
 	var query = r.URL.Query()
 
-	var debugQuery string
+	debugQuery := url.Values{}
 	// if we have a debug param add it to our URLs
 	if query.Get("debug") == "true" {
-		debugQuery = "?debug=true"
+		debugQuery.Set("debug", "true")
 
 		// update our map to include the debug layers
 		m = m.AddDebugLayers()
@@ -126,7 +125,7 @@ func (req HandleMapCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Reques
 			MinZoom: m.Layers[i].MinZoom,
 			MaxZoom: m.Layers[i].MaxZoom,
 			Tiles: []string{
-				fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, "maps", req.mapName, m.Layers[i].MVTName(), "{z}/{x}/{y}.pbf"), debugQuery),
+				buildCapabilitiesURL(r, []string{"maps", req.mapName, m.Layers[i].MVTName(), "{z}/{x}/{y}.pbf"}, debugQuery),
 			},
 		}
 
@@ -146,7 +145,7 @@ func (req HandleMapCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		tileJSON.VectorLayers = append(tileJSON.VectorLayers, layer)
 	}
 
-	tileURL := fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, "maps", req.mapName, "{z}/{x}/{y}.pbf"), debugQuery)
+	tileURL := buildCapabilitiesURL(r, []string{"maps", req.mapName, "{z}/{x}/{y}.pbf"}, debugQuery)
 
 	// build our URL scheme for the tile grid
 	tileJSON.Tiles = append(tileJSON.Tiles, tileURL)

--- a/server/server.go
+++ b/server/server.go
@@ -2,8 +2,10 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/dimfeld/httptreemux"
 
@@ -129,6 +131,25 @@ var URLRoot = func(r *http.Request) *url.URL {
 	}
 
 	return &root
+}
+
+// buildCapabilitiesURL is responsible for building the various URLs which are returned by
+// the capabilities endpoints using the request, uri parts, and query params the function
+// will determine the protocol host:port and URI prefix that need to be included based on
+// user defined configurations and request context
+func buildCapabilitiesURL(r *http.Request, uriParts []string, query url.Values) string {
+	uri := path.Join(uriParts...)
+	q := query.Encode()
+	if q != "" {
+		// prepend our query identifier
+		q = "?" + q
+	}
+
+	// usually the url.URL package would be used for building the URL, but the
+	// uri template for the tiles contains characters that the package does not like:
+	// {z}/{x}/{y}. These values are escaped during the String() call which does not
+	// work for the capabilities URLs.
+	return fmt.Sprintf("%v%v%v", URLRoot(r), path.Join(URIPrefix, uri), q)
 }
 
 // corsHanlder is used to respond to all OPTIONS requests for registered routes

--- a/server/server.go
+++ b/server/server.go
@@ -2,9 +2,8 @@
 package server
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
+	"net/url"
 
 	"github.com/dimfeld/httptreemux"
 
@@ -35,6 +34,10 @@ var (
 	// configurable via the tegola config.toml file (set in main.go)
 	Headers = map[string]string{}
 
+	// URIPrefix sets a prefix on all server endpoints. This is often used
+	// when the server sits behind a reverse proxy with a prefix (i.e. /tegola)
+	URIPrefix = "/"
+
 	// DefaultCORSHeaders define the default CORS response headers added to all requests
 	DefaultCORSHeaders = map[string]string{
 		"Access-Control-Allow-Origin":  "*",
@@ -45,7 +48,7 @@ var (
 // NewRouter set's up the our routes.
 func NewRouter(a *atlas.Atlas) *httptreemux.TreeMux {
 	r := httptreemux.New()
-	group := r.NewGroup("/")
+	group := r.NewGroup(URIPrefix)
 
 	// one handler to respond to all OPTIONS requests for registered routes with our CORS headers
 	r.OptionsHandler = corsHandler
@@ -94,38 +97,15 @@ func Start(a *atlas.Atlas, port string) *http.Server {
 	return srv
 }
 
-// hostName determines the hostname:port to return based on the following hierarchy
-// - HostName / Port values as configured via the config file
-// - The request host / port if config HostName or Port is missing
+// hostName determines weather to use an user defined HostName
+// or the host from the incoming request
 func hostName(r *http.Request) string {
-	var requestHostname string
-	var requestPort string
-
-	substrs := strings.Split(r.Host, ":")
-
-	switch len(substrs) {
-	case 1:
-		requestHostname = substrs[0]
-	case 2:
-		requestHostname = substrs[0]
-		requestPort = substrs[1]
-	default:
-		log.Warnf("multiple colons (':') in host string: %v", r.Host)
+	// if the HostName has been configured, don't mutate it
+	if HostName != "" {
+		return HostName
 	}
 
-	retHost := HostName
-	if HostName == "" {
-		retHost = requestHostname
-	}
-
-	if Port != "" && Port != "none" {
-		return retHost + Port
-	}
-	if requestPort != "" && Port != "none" {
-		return retHost + ":" + requestPort
-	}
-
-	return retHost
+	return r.Host
 }
 
 // various checks to determin if the request is http or https. the scheme is needed for the TileURLs
@@ -142,8 +122,13 @@ func scheme(r *http.Request) string {
 
 // URLRoot builds a string containing the scheme, host and port based on a combination of user defined values,
 // headers and request parameters. The function is public so it can be overridden for other implementations.
-var URLRoot = func(r *http.Request) string {
-	return fmt.Sprintf("%v://%v", scheme(r), hostName(r))
+var URLRoot = func(r *http.Request) *url.URL {
+	root := url.URL{
+		Scheme: scheme(r),
+		Host:   hostName(r),
+	}
+
+	return &root
 }
 
 // corsHanlder is used to respond to all OPTIONS requests for registered routes

--- a/server/server_internal_test.go
+++ b/server/server_internal_test.go
@@ -15,23 +15,26 @@ func TestHostName(t *testing.T) {
 		expected string
 	}
 
-	fn := func(t *testing.T, tc tcase) {
-		// set the package variable
-		HostName = tc.hostName
-		Port = tc.port
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			// set the package variable
+			HostName = tc.hostName
+			Port = tc.port
 
-		url, err := url.Parse(tc.url)
-		if err != nil {
-			t.Errorf("url(%v) parse error, expected nil got %v", tc.url, err)
-			return
-		}
+			url, err := url.Parse(tc.url)
+			if err != nil {
+				t.Errorf("url(%v) parse error, expected nil got %v", tc.url, err)
+				return
+			}
 
-		req := http.Request{URL: url, Host: url.Host}
+			req := http.Request{URL: url, Host: url.Host}
 
-		output := hostName(&req)
-		if output != tc.expected {
-			t.Errorf("hostname, expected %v got %v", tc.expected, output)
-			return
+			output := hostName(&req)
+			if output != tc.expected {
+				t.Errorf("hostname, expected %v got %v", tc.expected, output)
+				return
+			}
+
 		}
 	}
 
@@ -52,7 +55,7 @@ func TestHostName(t *testing.T) {
 			// Hostname set, no port in config, but port in url.  Expect <config_host>:<url_port>.
 			url:      "http://localhost:8080/capabilities",
 			hostName: "cdn.tegola.io",
-			expected: "cdn.tegola.io:8080",
+			expected: "cdn.tegola.io",
 		},
 		"hostname set no port in config or url": {
 			url:      "http://localhost/capabilities",
@@ -66,8 +69,7 @@ func TestHostName(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		t.Run(name, func(t *testing.T) { fn(t, tc) })
+		t.Run(name, fn(tc))
 	}
 }
 
@@ -77,10 +79,13 @@ func TestScheme(t *testing.T) {
 		expected string
 	}
 
-	fn := func(t *testing.T, tc tcase) {
-		output := scheme(&tc.request)
-		if output != tc.expected {
-			t.Errorf("scheme, expected (%v) got (%v)", tc.expected, output)
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			output := scheme(&tc.request)
+			if output != tc.expected {
+				t.Errorf("scheme, expected (%v) got (%v)", tc.expected, output)
+			}
 		}
 	}
 
@@ -109,7 +114,6 @@ func TestScheme(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		t.Run(name, func(t *testing.T) { fn(t, tc) })
+		t.Run(name, fn(tc))
 	}
 }

--- a/server/server_internal_test.go
+++ b/server/server_internal_test.go
@@ -51,8 +51,15 @@ func TestHostName(t *testing.T) {
 			port:     "none",
 			expected: "cdn.tegola.io",
 		},
+		"hostname set port set": {
+			// With hostname set and port set to "none" in config, expect "cdn.tegola.io"
+			url:      "http://localhost:8080/capabilities",
+			hostName: "cdn.tegola.io",
+			port:     ":9090",
+			expected: "cdn.tegola.io",
+		},
 		"hostname set port in request": {
-			// Hostname set, no port in config, but port in url.  Expect <config_host>:<url_port>.
+			// Hostname set, no port in config, but port in url.  Expect <config_host>
 			url:      "http://localhost:8080/capabilities",
 			hostName: "cdn.tegola.io",
 			expected: "cdn.tegola.io",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,9 +1,12 @@
 package server_test
 
 import (
+	"crypto/tls"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 
 	"github.com/dimfeld/httptreemux"
 	"github.com/go-spatial/geom"
@@ -15,7 +18,7 @@ import (
 // test server config
 const (
 	httpPort       = ":8080"
-	serverVersion  = "0.4.0"
+	serverVersion  = "0.10.0"
 	serverHostName = "tegola.io"
 )
 
@@ -88,6 +91,45 @@ func doRequest(a *atlas.Atlas, method string, uri string, body io.Reader) (w *ht
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 	return w, router, nil
+}
+
+func TestURLRoot(t *testing.T) {
+	type tcase struct {
+		request  http.Request
+		hostName string
+		expected string
+	}
+
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			server.HostName = tc.hostName
+
+			output := server.URLRoot(&tc.request).String()
+			if output != tc.expected {
+				t.Errorf("expected (%v) got (%v)", tc.expected, output)
+			}
+		}
+	}
+
+	tests := map[string]tcase{
+		"http": {
+			request:  http.Request{},
+			hostName: serverHostName,
+			expected: fmt.Sprintf("http://%v", serverHostName),
+		},
+		"https": {
+			request: http.Request{
+				TLS: &tls.ConnectionState{},
+			},
+			hostName: serverHostName,
+			expected: fmt.Sprintf("https://%v", serverHostName),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, fn(tc))
+	}
 }
 
 // pre test setup phase

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -93,6 +93,24 @@ func doRequest(a *atlas.Atlas, method string, uri string, body io.Reader) (w *ht
 	return w, router, nil
 }
 
+// pre test setup phase
+func init() {
+	server.Version = serverVersion
+	server.HostName = serverHostName
+
+	testMap := atlas.NewWebMercatorMap(testMapName)
+	testMap.Attribution = testMapAttribution
+	testMap.Center = testMapCenter
+	testMap.Layers = append(testMap.Layers,
+		testLayer1,
+		testLayer2,
+		testLayer3,
+	)
+
+	// register a map with atlas
+	atlas.AddMap(testMap)
+}
+
 func TestURLRoot(t *testing.T) {
 	type tcase struct {
 		request  http.Request
@@ -130,22 +148,4 @@ func TestURLRoot(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, fn(tc))
 	}
-}
-
-// pre test setup phase
-func init() {
-	server.Version = serverVersion
-	server.HostName = serverHostName
-
-	testMap := atlas.NewWebMercatorMap(testMapName)
-	testMap.Attribution = testMapAttribution
-	testMap.Center = testMapCenter
-	testMap.Layers = append(testMap.Layers,
-		testLayer1,
-		testLayer2,
-		testLayer3,
-	)
-
-	// register a map with atlas
-	atlas.AddMap(testMap)
 }


### PR DESCRIPTION
Added the webserver config property uri_prefix which allows for
setting an API route prefix. This is commonly used when tegola
is run behind a reverse proxy (i.e. example.com/tegola). Certain
routes (i.e. capabilities) build URLs which are included in the
response and then passed back to the proxy. Without the ability
to set a URI prefix, the URLs in the capabilities responses
will not be useable by the consuming client.

Setting the webserver hostname now ignores the server port. It's
assumed that if the user is setting the hostname they want full
control of it.

closes #136