### PR TITLE
fix: wrong cli check

### DIFF
--- a/cmd/tegola/cmd/cache/cache.go
+++ b/cmd/tegola/cmd/cache/cache.go
@@ -226,13 +226,13 @@ TileChannelLoop:
 func IsValidLat(f64 float64) bool { return -90.0 <= f64 && f64 <= 90.0 }
 func IsValidLatString(lat string) (float64, bool) {
 	f64, err := strconv.ParseFloat(strings.TrimSpace(lat), 64)
-	return f64, err == nil || IsValidLat(f64)
+	return f64, err == nil && IsValidLat(f64)
 }
 
 func IsValidLng(f64 float64) bool { return -180.0 <= f64 && f64 <= 180.0 }
 func IsValidLngString(lng string) (float64, bool) {
 	f64, err := strconv.ParseFloat(strings.TrimSpace(lng), 64)
-	return f64, err == nil || IsValidLng(f64)
+	return f64, err == nil && IsValidLng(f64)
 }
 
 func sliceFromRange(min, max uint) ([]uint, error) {


### PR DESCRIPTION
During #655, this command line check seems to fail to check lat lng validity by validating every float.