### PR TITLE
maths: fix dropped error

### DIFF
--- a/maths/triangle.go
+++ b/maths/triangle.go
@@ -1124,6 +1124,9 @@ func makeValid(plygs ...[]Line) (polygons [][][]Pt, err error) {
 		stime = etime
 	*/
 	triangleGraph, err := edgeMap.FindTriangles()
+	if err != nil {
+		return polygons, err
+	}
 	/*
 		etime = time.Now()
 		log.Println("Find Triangles took: ", etime.Sub(stime))


### PR DESCRIPTION
This fixes a dropped error variable in the `maths` package.