### PR TITLE
provider/postgis: fix dropped errors

### DIFF
--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -125,6 +125,9 @@ func CreateProvider(config dict.Dicter) (*Provider, error) {
 
 	sslmode := DefaultSSLMode
 	sslmode, err = config.String(ConfigKeySSLMode, &sslmode)
+	if err != nil {
+		return nil, err
+	}
 
 	sslkey := DefaultSSLKey
 	sslkey, err = config.String(ConfigKeySSLKey, &sslkey)

--- a/provider/postgis/util.go
+++ b/provider/postgis/util.go
@@ -246,6 +246,9 @@ func decipherFields(ctx context.Context, geomFieldname, idFieldname string, desc
 			// the id has to be parsed once but it can also be a tag
 			if !idParsed {
 				gid, err = gId(values[i])
+				if err != nil {
+					return 0, nil, nil, err
+				}
 				idParsed = true
 				break
 			}


### PR DESCRIPTION
This fixes two dropped `err` variables in `provider/postgis`.