### PR TITLE
cache/s3: replace deprecated S3 function

### DIFF
--- a/cache/s3/s3.go
+++ b/cache/s3/s3.go
@@ -154,9 +154,11 @@ func New(config dict.Dicter) (cache.Interface, error) {
 	// setup the s3 session.
 	// if the accessKey and secreteKey are not provided (static creds) then the provider chain is used
 	// http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
-	s3cache.Client = s3.New(
-		session.New(&awsConfig),
-	)
+	sess, err := session.NewSession(&awsConfig)
+	if err != nil {
+		return nil, err
+	}
+	s3cache.Client = s3.New(sess)
 
 	// check for control_access_list env var
 	acl := os.Getenv("AWS_ACL")


### PR DESCRIPTION
This replaces the deprecated `session.New()`.

`go doc github.com/aws/aws-sdk-go/aws/session.New`
>Deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.
