### PR TITLE
Version bumps in Dockerfile

### DIFF
--- a/.github/workflows/on_release_publish.yml
+++ b/.github/workflows/on_release_publish.yml
@@ -45,7 +45,7 @@ jobs:
         name: version
 
     - name: Set tegola version
-      run: echo "::set-env name=VERSION::$(cat version/version.txt)"
+      run: echo "VERSION=$(cat version/version.txt)" >> $GITHUB_ENV
 
     - name: Set up Go 1.14
       uses: actions/setup-go@v2
@@ -140,7 +140,7 @@ jobs:
         name: version
 
     - name: Set tegola version
-      run: echo "::set-env name=VERSION::$(cat version/version.txt)"
+      run: echo "VERSION=$(cat version/version.txt)" >> $GITHUB_ENV
 
     - name: Build and tag Docker container
       run: |
@@ -176,7 +176,7 @@ jobs:
         name: version
 
     - name: Set tegola version
-      run: echo "::set-env name=VERSION::$(cat version/version.txt)"
+      run: echo "VERSION=$(cat version/version.txt)" >> $GITHUB_ENV
 
     - name: Set up Go 1.14
       uses: actions/setup-go@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@
 #  $ docker run -v /path/to/docker-config:/opt/tegola_config -p 8080 tegola serve
 
 # Intermediary container for building
-FROM golang:1.14.1-alpine3.11 AS build
+FROM golang:1.15.6-alpine3.12 AS build
 
 ARG VERSION="Version Not Set"
 ENV VERSION="${VERSION}"
@@ -36,8 +36,8 @@ ENV VERSION="${VERSION}"
 # incurs approximately 1:30 extra build time (1:54 vs 0:27) to install packages.  Doesn't impact
 # development as these layers are drawn from cache after the first build.
 RUN apk update \ 
-	&& apk add musl-dev=1.1.24-r2 \
-	&& apk add gcc=9.3.0-r0
+	&& apk add musl-dev=1.1.24-r10 \
+	&& apk add gcc=9.3.0-r2
 
 # Set up source for compilation
 RUN mkdir -p /go/src/github.com/go-spatial/tegola
@@ -45,11 +45,11 @@ COPY . /go/src/github.com/go-spatial/tegola
 
 # Build binary
 RUN cd /go/src/github.com/go-spatial/tegola/cmd/tegola \
-	&& go build -v -ldflags "-w -X github.com/go-spatial/tegola/cmd/tegola/cmd.Version=${VERSION}" -gcflags "-N -l" -o /opt/tegola \ 
+ 	&& go build -v -ldflags "-w -X 'github.com/go-spatial/tegola/cmd/tegola/cmd.Version=${VERSION}'" -gcflags "-N -l" -o /opt/tegola \
 	&& chmod a+x /opt/tegola
 
 # Create minimal deployment image, just alpine & the binary
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN apk update \
 	&& apk add ca-certificates \


### PR DESCRIPTION
* Bump Go to 1.5.6
* Bump alpine linux to 3.12
* Bump musl-dev to 1.1.24r10
* Bump gcc to 9.3.0-r2
* Fixed Go linker change that happened in Go 1.15