### PR TITLE
Add http end point observer

### DIFF
--- a/atlas/atlas.go
+++ b/atlas/atlas.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/go-spatial/tegola/internal/observer"
+
 	"github.com/go-spatial/tegola/observability"
 
 	"github.com/go-spatial/geom/slippy"
@@ -237,10 +239,16 @@ func (a *Atlas) SetObservability(o observability.Interface) {
 }
 
 func (a *Atlas) Observer() observability.Interface {
+	var o observability.Interface
 	if a == nil {
-		return defaultAtlas.Observer()
+		o = defaultAtlas.Observer()
+	} else {
+		o = a.observer
 	}
-	return a.observer
+	if _, ok := o.(observer.Null); ok {
+		return nil
+	}
+	return o
 }
 
 // AllMaps returns all registered maps in defaultAtlas

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -20,6 +20,12 @@ type Interface interface {
 	Purge(key *Key) error
 }
 
+// Wrapped Cache are for cache backend that wrap other cache backends
+// Original will return the first cache backend to be wrapped
+type Wrapped interface {
+	Original() Interface
+}
+
 // ParseKey will parse a string in the format /:map/:layer/:z/:x/:y into a Key struct. The :layer value is optional
 // ParseKey also supports other OS delimiters (i.e. Windows - "\")
 func ParseKey(str string) (*Key, error) {

--- a/cmd/internal/register/observers.go
+++ b/cmd/internal/register/observers.go
@@ -1,8 +1,6 @@
 package register
 
 import (
-	"log"
-
 	"github.com/go-spatial/tegola/dict"
 	"github.com/go-spatial/tegola/internal/p"
 	"github.com/go-spatial/tegola/observability"
@@ -13,6 +11,5 @@ func Observer(config dict.Dicter) (observability.Interface, error) {
 	if config != nil {
 		oType, _ = config.String("type", p.String("none"))
 	}
-	log.Printf("%v: %v", oType, config)
 	return observability.For(oType, config)
 }

--- a/internal/observer/null.go
+++ b/internal/observer/null.go
@@ -1,0 +1,20 @@
+package observer
+
+import "net/http"
+
+type Null struct{}
+
+// Handler does nothing.
+func (Null) Handler(string) http.Handler { return nil }
+
+// InstrumentedAPIHttpHandler does not do anything and just returns the handler
+func (Null) InstrumentedAPIHttpHandler(_, _ string, handler http.Handler) http.Handler {
+	return handler
+}
+
+// InstrumentedViewerHttpHandler does not do anything and just returns the handler
+func (Null) InstrumentedViewerHttpHandler(_, _ string, handler http.Handler) http.Handler {
+	return handler
+}
+
+func (Null) Name() string { return "none" }

--- a/observability/none.go
+++ b/observability/none.go
@@ -1,25 +1,10 @@
 package observability
 
 import (
-	"net/http"
-
 	"github.com/go-spatial/tegola/dict"
+	"github.com/go-spatial/tegola/internal/observer"
 )
 
-var NullObserver nullObserverType
+var NullObserver observer.Null
 
 func noneInit(dict.Dicter) (Interface, error) { return NullObserver, nil }
-
-type nullObserverType struct{}
-
-// Handler does nothing.
-func (nullObserverType) Handler(string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { return })
-}
-
-// InstrumentedHttpHandler does not do anything and just returns the handler
-func (nullObserverType) InstrumentedHttpHandler(_, _ string, handler http.Handler) http.Handler {
-	return handler
-}
-
-func (nullObserverType) Name() string { return "none" }

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -27,22 +27,43 @@ type InitFunc func(dicter dict.Dicter) (Interface, error)
 
 // Interface
 type Interface interface {
+
 	// Handler returns a http.Handler for the metrics route
 	Handler(route string) http.Handler
-	// InstrumentedHttpHandler returns an http.Handler that will instrument the given http handler, for the
-	// route and method that was given
-	InstrumentedHttpHandler(method, route string, handler http.Handler) http.Handler
 
 	// Returns the name of observer
 	Name() string
+
+	APIObserver
+	ViewerObserver
 }
 
-// InstrumentHandler is a convenience  function
-func InstrumentHandler(method, route string, observer Interface, handler http.Handler) (string, string, http.Handler) {
+type APIObserver interface {
+	// InstrumentedAPIHttpHandler returns an http.Handler that will instrument the given http handler, for the
+	// route and method that was given
+	InstrumentedAPIHttpHandler(method, route string, handler http.Handler) http.Handler
+}
+
+type ViewerObserver interface {
+	// InstrumentedViewerHttpHandler returns an http.Handler that will instrument the given http handler, for the
+	// route and method that was given
+	InstrumentedViewerHttpHandler(method, route string, handler http.Handler) http.Handler
+}
+
+// InstrumentAPIHandler is a convenience  function
+func InstrumentAPIHandler(method, route string, observer APIObserver, handler http.Handler) (string, string, http.Handler) {
 	if observer == nil {
 		return method, route, handler
 	}
-	return method, route, observer.InstrumentedHttpHandler(method, route, handler)
+	return method, route, observer.InstrumentedAPIHttpHandler(method, route, handler)
+}
+
+// InstrumentViewHandler is a convenience  function
+func InstrumentViewerHandler(method, route string, observer ViewerObserver, handler http.Handler) (string, string, http.Handler) {
+	if observer == nil {
+		return method, route, handler
+	}
+	return method, route, observer.InstrumentedViewerHttpHandler(method, route, handler)
 }
 
 // observers is a list of the current that have been registered with the system

--- a/observability/prometheus/http.go
+++ b/observability/prometheus/http.go
@@ -1,0 +1,123 @@
+package prometheus
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type httpHandler struct {
+	observeVars       []string
+	URLPrefix         string
+	inFlightGauge     prometheus.Gauge
+	counter           *prometheus.CounterVec
+	durationSeconds   *prometheus.HistogramVec
+	responseSizeBytes *prometheus.HistogramVec
+}
+
+var (
+	httpHandlerDurationBuckets     = []float64{.25, .5, 1, 2.5, 5, 10}
+	httpHandlerResponseSizeBuckets = []float64{float64(500 * kb), float64(1 * mb), float64(5 * mb)}
+)
+
+func newHttpHandler(registry prometheus.Registerer, prefix string, URLPrefix string, observeVars []string) *httpHandler {
+	handler := httpHandler{
+		observeVars: observeVars,
+		URLPrefix:   URLPrefix,
+	}
+
+	handler.inFlightGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: prefix + "_flight_requests",
+		Help: "A gauge of requests currently being served by the wrapped handler.",
+	})
+
+	handler.counter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: prefix + "_requests_total",
+			Help: "A counter for requests to the wrapped handler.",
+		},
+		[]string{"code", "method"},
+	)
+
+	durationLabels := []string{"handler", "method"}
+	// duration is partitioned by the HTTP method and handler. It uses custom
+	// buckets based on the expected request duration.
+	handler.durationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    prefix + "_duration_seconds",
+			Help:    "A histogram of latencies for requests.",
+			Buckets: httpHandlerDurationBuckets,
+		},
+		durationLabels,
+	)
+
+	// responseSize has no labels, making it a zero-dimensional
+	// ObserverVec.
+	handler.responseSizeBytes = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    prefix + "_response_size_bytes",
+			Help:    "A histogram of response sizes for requests.",
+			Buckets: httpHandlerResponseSizeBuckets,
+		},
+		[]string{},
+	)
+
+	registry.MustRegister(
+		handler.inFlightGauge,
+		handler.counter,
+		handler.durationSeconds,
+		handler.responseSizeBytes,
+	)
+
+	return &handler
+}
+
+func (handler *httpHandler) instrumentHandlerDuration(originalRoute string, next http.Handler) http.HandlerFunc {
+	type partKeyVal struct {
+		Name  string
+		Index int
+	}
+	var partsMap []partKeyVal
+	parts := strings.Split(originalRoute, "/")
+	if len(handler.observeVars) > 0 {
+		partsMap = make([]partKeyVal, 0, len(handler.observeVars))
+	partsLoop:
+		for i, part := range parts {
+			if !strings.HasPrefix(part, ":") {
+				continue
+			}
+			for _, lbl := range handler.observeVars {
+				if part == lbl {
+					continue partsLoop
+				}
+			}
+			partsMap = append(partsMap, partKeyVal{Name: part, Index: i})
+		}
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var routeURL = r.URL.Path
+
+		parts := strings.Split(strings.TrimPrefix(routeURL, handler.URLPrefix), "/")
+
+		for _, val := range partsMap {
+			parts[val.Index] = val.Name
+		}
+		labels := prometheus.Labels{
+			"handler": strings.Join(parts, "/"),
+		}
+		promhttp.InstrumentHandlerDuration(handler.durationSeconds.MustCurryWith(labels), next).ServeHTTP(w, r)
+	})
+}
+
+func (handler *httpHandler) InstrumentedHttpHandler(_, route string, next http.Handler) http.Handler {
+	return promhttp.InstrumentHandlerInFlight(handler.inFlightGauge,
+		handler.instrumentHandlerDuration(route,
+			promhttp.InstrumentHandlerCounter(handler.counter,
+				promhttp.InstrumentHandlerResponseSize(handler.responseSizeBytes, next),
+			),
+		),
+	)
+}

--- a/observability/prometheus/prometheus.go
+++ b/observability/prometheus/prometheus.go
@@ -3,6 +3,8 @@ package prometheus
 import (
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/go-spatial/tegola/observability"
 
 	"github.com/go-spatial/tegola/dict"
@@ -21,6 +23,9 @@ const (
 
 const (
 	Name = "prometheus"
+
+	httpAPI    = "tegola_api"
+	httpViewer = "tegola_viewer"
 )
 
 func init() {
@@ -31,19 +36,57 @@ func init() {
 }
 
 type observer struct {
+	// URLPrefix is the server's prefix
+	URLPrefix string
+
+	// observeVars are the vars (:foo) in a url that should be turned into a label
+	// Default values for this via new is []string{":map_name",":layer_name",":z"}
+	observeVars []string
+
+	httpHandlers map[string]*httpHandler
+	registry     prometheus.Registerer
 }
 
 func New(config dict.Dicter) (observability.Interface, error) {
 	// We don't have anything for now for the config
 	var obs observer
+	obs.registry = prometheus.DefaultRegisterer
+	obs.httpHandlers = make(map[string]*httpHandler)
+
+	obs.observeVars, _ = config.StringSlice("variables")
+	if len(obs.observeVars) == 0 {
+		obs.observeVars = []string{":map_name", ":layer_name", ":z"}
+	}
 
 	return &obs, nil
 }
 
+func (*observer) Name() string { return Name }
+
 func (observer) Handler(string) http.Handler { return promhttp.Handler() }
 
-func (obs *observer) InstrumentedHttpHandler(method, route string, handler http.Handler) http.Handler {
-	return handler
+func (obs *observer) InstrumentedAPIHttpHandler(method, route string, next http.Handler) http.Handler {
+	if obs == nil {
+		return next
+	}
+	handler := obs.httpHandlers[httpAPI]
+	if handler == nil {
+		// need to initialize the handler
+		handler = newHttpHandler(obs.registry, httpAPI, obs.URLPrefix, obs.observeVars)
+		obs.httpHandlers[httpAPI] = handler
+	}
+	return handler.InstrumentedHttpHandler(method, route, next)
 }
 
-func (*observer) Name() string { return Name }
+func (obs *observer) InstrumentedViewerHttpHandler(method, route string, next http.Handler) http.Handler {
+	if obs == nil {
+		return next
+	}
+	handler := obs.httpHandlers[httpViewer]
+	if handler == nil {
+		// need to initialize the handler
+		handler = newHttpHandler(obs.registry, httpViewer, obs.URLPrefix, obs.observeVars)
+		obs.httpHandlers[httpViewer] = handler
+	}
+	return handler.InstrumentedHttpHandler(method, route, next)
+}

--- a/server/viewer.go
+++ b/server/viewer.go
@@ -20,8 +20,8 @@ func setupViewer(o observability.Interface, group *httptreemux.Group) {
 		fs: bindata.AssetFileSystem(),
 	}
 
-	group.UsingContext().Handler(observability.InstrumentHandler(http.MethodGet, "/", o, http.FileServer(&prefixStripper)))
-	group.UsingContext().Handler(observability.InstrumentHandler(http.MethodGet, "/*path", o, http.FileServer(&prefixStripper)))
+	group.UsingContext().Handler(observability.InstrumentViewerHandler(http.MethodGet, "/", o, http.FileServer(&prefixStripper)))
+	group.UsingContext().Handler(observability.InstrumentViewerHandler(http.MethodGet, "/*path", o, http.FileServer(&prefixStripper)))
 }
 
 type FilePathPrefixStripper struct {


### PR DESCRIPTION
[observability] Split out httpAPI and httpViewer instrumentation

Split out the Observability interface so that API route and dealt with separately from the
viewer routes.

Moved Null Observer to an internal package, treating nil as a Null Observer.
Prometheus observer can be configured to indicate which API vars should be filled in. Default variables
are :map_name, :layer_name and :z.

fixes #754 
