### PR TITLE
Make sure to strip "/" for static files if URIPrefix ends with a "/"

### DIFF
--- a/server/viewer.go
+++ b/server/viewer.go
@@ -29,8 +29,15 @@ type FilePathPrefixStripper struct {
 }
 
 func (fsps *FilePathPrefixStripper) Open(name string) (http.File, error) {
-	if URIPrefix != "/" {
-		name = strings.TrimPrefix(name, URIPrefix)
+	// Don't want to modify the Global.
+	// TODO(GDEY): Why is URIPrefix a global? Can it change after startup?
+	prefix := URIPrefix
+	// Strip any leading "/" from the URIPrefix.
+	if len(prefix) > 0 && prefix[len(prefix)-1] == '/' {
+		prefix = prefix[:len(prefix)-1]
+	}
+	if prefix != "" {
+		name = strings.TrimPrefix(name, prefix)
 	}
 
 	return fsps.fs.Open(name)


### PR DESCRIPTION
When serving up static files we need to strip any proxy prefixes we may add onto the URL.
We forgot to check to see if the prefix had a "/" at the end of it, and if it did made sure
to strip it out, as static files should always start with a "/". However, if we did not remove
the "/" at the end of the prefix that we then use to trim the url; we would end up trimming off
the starting "/". This fixes that.

Fixes #735