### PR TITLE
Refactor tegola_lambda CI to use Amazon Linux for building

### DIFF
--- a/.github/actions/amazon-linux-build-action/Dockerfile
+++ b/.github/actions/amazon-linux-build-action/Dockerfile
@@ -1,0 +1,22 @@
+# Amazon Linux is used to build tegola_linux so the CGO requirements are linked correctly
+FROM amazonlinux:latest
+
+# install build deps
+RUN yum install -y tar gzip gcc
+
+# install Go
+ENV GOLANG_VERSION 1.16.6
+ENV GOLANG_VERSION_SHA256 be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d
+
+RUN curl -o golang.tar.gz https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz \
+	&& echo "$GOLANG_VERSION_SHA256 golang.tar.gz" | sha256sum --strict --check \
+	&& tar -C /usr/local -xzf golang.tar.gz \
+	&& rm golang.tar.gz
+
+ENV PATH /usr/local/go/bin:$PATH
+
+# entrypoint.sh holds the build instructions for tegola_lambda
+COPY entrypoint.sh /entrypoint.sh
+
+# run the build script when this container starts up
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/amazon-linux-build-action/action.yml
+++ b/.github/actions/amazon-linux-build-action/action.yml
@@ -1,0 +1,12 @@
+name: 'Amazon Linux build container'
+description: 'Used for building tegola_lambda'
+inputs:
+  args:  
+    description: 'Should always be three dots'
+    required: true
+    default: '...'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.args }}

--- a/.github/actions/amazon-linux-build-action/entrypoint.sh
+++ b/.github/actions/amazon-linux-build-action/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -l
+
+# This file expects to run in a Docker container running on GitHub Actions. 
+# GitHub will automatically mount the source code directory as a Docker volume 
+# using the following docker run flag:
+#
+#	-v "/home/runner/work/tegola/tegola":"/github/workspace"
+#
+# The workdir is set using the following docker run flag:
+#
+#	--workdir /github/workspace
+#
+# The VERSION env var is set using the following docker run flag:
+# 
+#	-e VERSION
+#
+
+# move to the tegola_lambda folder
+cd cmd/tegola_lambda
+
+# build the binary
+go build -mod vendor -ldflags "-w -X main.Version=$VERSION"

--- a/.github/workflows/on_pr_push.yml
+++ b/.github/workflows/on_pr_push.yml
@@ -4,7 +4,7 @@ jobs:
 
   test:
     name: Test on Ubuntu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       # label used to access the service container

--- a/.github/workflows/on_release_publish.yml
+++ b/.github/workflows/on_release_publish.yml
@@ -8,7 +8,7 @@ jobs:
 
   gen_version:
     name: Generate software version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     # on release we want to use release.tag_name for the version
@@ -22,7 +22,7 @@ jobs:
       run: echo ${{ github.sha }} | cut -c1-7 > ${{ github.workspace }}/version.txt
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v2
       with:
         name: version
         path: ${{ github.workspace }}/version.txt
@@ -30,7 +30,7 @@ jobs:
   build_linux:
     name: Build for Linux and AWS Lambda
     needs: gen_version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out code
@@ -65,7 +65,7 @@ jobs:
         zip -9 -D tegola.zip tegola
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v2
       with:
         name: tegola_linux_amd64
         path: cmd/tegola/tegola.zip
@@ -81,13 +81,27 @@ jobs:
         asset_name: tegola_linux_amd64.zip
         asset_content_type: application/zip
 
+  build_tegola_lambda:
+    name: Build tegola_lambda on Amazon Linux
+    needs: gen_version
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Download version artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: version
+
+    - name: Set tegola version
+      run: echo "VERSION=$(cat version/version.txt)" >> $GITHUB_ENV
+
     - name: Build tegola_lambda
-      env:
-        # build architecture
-        GOOS: linux
-      run: |
-          cd cmd/tegola_lambda
-          go build -mod vendor -ldflags "-w -X main.Version=${VERSION}"
+      uses: ./.github/actions/amazon-linux-build-action
+      with:
+        args: '...'
 
     # workaround for archives losing permissions 
     # https://github.com/actions/upload-artifact/issues/38
@@ -97,7 +111,7 @@ jobs:
         zip -9 -D tegola.zip tegola_lambda
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v2
       with:
         name: tegola_lambda
         path: cmd/tegola_lambda/tegola.zip
@@ -150,7 +164,7 @@ jobs:
         zip -9 -D tegola.zip tegola
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v2
       with:
         name: tegola_darwin_amd64
         path: cmd/tegola/tegola.zip
@@ -169,7 +183,7 @@ jobs:
   build_docker:
     name: Build Docker image and publish to Docker Hub
     needs: gen_version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKERHUB_ORG: gospatial
       DOCKERHUB_REPO: tegola


### PR DESCRIPTION
AWS Lambda uses Amazon Linux for Lambda executions. The previous
build pipeline was using Ubuntu 18.04 to build tegola_lambda
which had GLIB location parity with Amazon Linux. After upgrading
to Ubuntu 20.04 the GLIB references between Ubuntu and Amazon Linux
are no longer in parity so tegola_lambda fails to find GLIB during
Lambda execution.

This commit accomplished the following:

* build tegola_lambda using Amazon Linux rather than Ubuntu
* move from using ubuntu-latest to ubuntu-20.04 in GH actions.

closes #789