### PR TITLE
Feature: adds configurable query parameters to tile endpoints

### DIFF
--- a/atlas/atlas.go
+++ b/atlas/atlas.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-spatial/geom/slippy"
 	"github.com/go-spatial/tegola"
 	"github.com/go-spatial/tegola/cache"
+	"github.com/go-spatial/tegola/config"
 	"github.com/go-spatial/tegola/internal/observer"
 	"github.com/go-spatial/tegola/observability"
 )
@@ -77,6 +78,10 @@ type Atlas struct {
 
 	// holds a reference to the observer backend
 	observer observability.Interface
+
+	// holds a reference to configured query parameters for maps
+	// key = map name
+	params map[string][]config.QueryParameter
 
 	// publishBuildInfo indicates if we should publish the build info on change of observer
 	// this is set by calling PublishBuildInfo, which will publish
@@ -211,6 +216,36 @@ func (a *Atlas) AddMap(m Map) {
 	}
 
 	a.maps[m.Name] = m
+}
+
+// AddParams adds the given query parameters to the atlas params map
+// keyed by the map name, with upper-cased tokens
+func (a *Atlas) AddParams(name string, params []config.QueryParameter) {
+	if a == nil {
+		defaultAtlas.AddParams(name, params)
+		return
+	}
+	if a.params == nil {
+		a.params = make(map[string][]config.QueryParameter)
+	}
+	a.params[name] = config.QueryParameters(params).Clean()
+}
+
+// GetParams returns any configured query parameters for the given
+// map by name
+func (a *Atlas) GetParams(name string) []config.QueryParameter {
+	if a == nil {
+		return defaultAtlas.GetParams(name)
+	}
+	return a.params[name]
+}
+
+// HasParams returns true if the given map by name has configured query parameters
+func (a *Atlas) HasParams(name string) bool {
+	if a == nil {
+		return defaultAtlas.HasParams(name)
+	}
+	return len(a.params[name]) > 0
 }
 
 // GetCache returns the registered cache if one is registered, otherwise nil

--- a/atlas/layer.go
+++ b/atlas/layer.go
@@ -17,10 +17,10 @@ type Layer struct {
 	// default tags to include when encoding the layer. provider tags take precedence
 	DefaultTags map[string]interface{}
 	GeomType    geom.Geometry
-	// DontSimplify indicates wheather feature simplification should be applied.
+	// DontSimplify indicates whether feature simplification should be applied.
 	// We use a negative in the name so the default is to simplify
 	DontSimplify bool
-	// DontClip indicates wheather feature clipping should be applied.
+	// DontClip indicates whether feature clipping should be applied.
 	// We use a negative in the name so the default is to clip
 	DontClip bool
 }

--- a/atlas/map.go
+++ b/atlas/map.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-spatial/tegola/provider/debug"
 )
 
-// NewMap creates a new map with the necessary default values
+// NewWebMercatorMap creates a new map with the necessary default values
 func NewWebMercatorMap(name string) Map {
 	return Map{
 		Name: name,
@@ -40,6 +40,7 @@ func NewWebMercatorMap(name string) Map {
 	}
 }
 
+// Map defines a Web Mercator map
 type Map struct {
 	Name string
 	// Contains an attribution to be displayed when the map is shown to a user.
@@ -348,7 +349,10 @@ func (m Map) encodeMVTTile(ctx context.Context, tile *slippy.Tile) ([]byte, erro
 	}
 
 	// add layers to our tile
-	mvtTile.AddLayers(mvtLayers...)
+	err := mvtTile.AddLayers(mvtLayers...)
+	if err != nil {
+		return nil, err
+	}
 
 	// generate the MVT tile
 	vtile, err := mvtTile.VTile(ctx)

--- a/cmd/internal/register/maps.go
+++ b/cmd/internal/register/maps.go
@@ -157,6 +157,11 @@ func Maps(a *atlas.Atlas, maps []config.Map, providers map[string]provider.Tiler
 			}
 			newMap.Layers = append(newMap.Layers, layer)
 		}
+
+		if len(m.Parameters) > 0 {
+			a.AddParams(string(m.Name), m.Parameters)
+		}
+
 		a.AddMap(newMap)
 	}
 	return nil

--- a/cmd/tegola/cmd/root.go
+++ b/cmd/tegola/cmd/root.go
@@ -18,7 +18,7 @@ var (
 	// parsed config
 	conf config.Config
 
-	// require cache
+	// RequireCache in this instance
 	RequireCache bool
 )
 
@@ -42,11 +42,11 @@ var RootCmd = &cobra.Command{
 	Use:   "tegola",
 	Short: "tegola is a vector tile server",
 	Long: fmt.Sprintf(`tegola is a vector tile server
-Version: %v`, build.Version),
+		Version: %v`, build.Version),
 	PersistentPreRunE: rootCmdValidatePersistent,
 }
 
-func rootCmdValidatePersistent(cmd *cobra.Command, args []string) (err error) {
+func rootCmdValidatePersistent(cmd *cobra.Command, _ []string) (err error) {
 	requireCache := RequireCache || cachecmd.RequireCache
 	cmdName := cmd.CalledAs()
 	switch cmdName {

--- a/config/config.go
+++ b/config/config.go
@@ -187,6 +187,22 @@ type QueryParameter struct {
 	Token string `toml:"token"`
 }
 
+// QueryParameters is an array of QueryParameter
+type QueryParameters []QueryParameter
+
+// Clean will return the list of parameters with all upper-cased token names
+func (params QueryParameters) Clean() QueryParameters {
+	var cleanParams []QueryParameter
+	for _, param := range params {
+		cleanParams = append(cleanParams, QueryParameter{
+			Name:  param.Name,
+			Token: strings.ToUpper(param.Token),
+		})
+	}
+
+	return cleanParams
+}
+
 // Validate checks the config for issues
 func (c *Config) Validate() error {
 

--- a/config/config.go
+++ b/config/config.go
@@ -183,8 +183,9 @@ func (ml MapLayer) GetName() (string, error) {
 // QueryParameter represents an HTTP query parameter specified for use with
 // a given map instance.
 type QueryParameter struct {
-	Name  string `toml:"name"`
-	Token string `toml:"token"`
+	Name    string `toml:"name"`
+	Token   string `toml:"token"`
+	Default string `toml:"default"`
 }
 
 // QueryParameters is an array of QueryParameter
@@ -195,8 +196,9 @@ func (params QueryParameters) Clean() QueryParameters {
 	var cleanParams []QueryParameter
 	for _, param := range params {
 		cleanParams = append(cleanParams, QueryParameter{
-			Name:  param.Name,
-			Token: strings.ToUpper(param.Token),
+			Name:    param.Name,
+			Token:   strings.ToUpper(param.Token),
+			Default: param.Default,
 		})
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -957,6 +957,113 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		"13 reserved parameter token": {
+			config: config.Config{
+				Providers: []env.Dict{
+					{
+						"name": "provider1",
+						"type": "mvt_test",
+					},
+				},
+				Maps: []config.Map{
+					{
+						Name: "bad_param",
+						Layers: []config.MapLayer{
+							{
+								ProviderLayer: "provider1.water_default_z",
+							},
+						},
+						Parameters: []config.QueryParameter{
+							{
+								Name:  "param",
+								Token: "!BBOX!",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: config.ErrParamTokenReserved{
+				MapName: "bad_param",
+				Parameter: config.QueryParameter{
+					Name:  "param",
+					Token: "!BBOX!",
+				},
+			},
+		},
+		"14 duplicate parameter name": {
+			config: config.Config{
+				Providers: []env.Dict{
+					{
+						"name": "provider1",
+						"type": "mvt_test",
+					},
+				},
+				Maps: []config.Map{
+					{
+						Name: "dupe_param_name",
+						Layers: []config.MapLayer{
+							{
+								ProviderLayer: "provider1.water_default_z",
+							},
+						},
+						Parameters: []config.QueryParameter{
+							{
+								Name:  "param",
+								Token: "!PARAM!",
+							},
+							{
+								Name:  "param",
+								Token: "!PARAM2!",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: config.ErrParamNameDuplicate{
+				MapName: "dupe_param_name",
+				Parameter: config.QueryParameter{
+					Name:  "param",
+					Token: "!PARAM2!",
+				},
+			},
+		},
+		"15 duplicate parameter token": {
+			config: config.Config{
+				Providers: []env.Dict{
+					{
+						"name": "provider1",
+						"type": "mvt_test",
+					},
+				},
+				Maps: []config.Map{
+					{
+						Name: "dupe_param_token",
+						Layers: []config.MapLayer{
+							{
+								ProviderLayer: "provider1.water_default_z",
+							},
+						},
+						Parameters: []config.QueryParameter{
+							{
+								Name:  "param",
+								Token: "!PARAM!",
+							},
+							{
+								Name:  "param2",
+								Token: "!PARAM!",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: config.ErrParamTokenDuplicate{
+				MapName: "dupe_param_token",
+				Parameter: config.QueryParameter{
+					Name:  "param2",
+					Token: "!PARAM!",
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/config/errors.go
+++ b/config/errors.go
@@ -13,6 +13,36 @@ func (e ErrMapNotFound) Error() string {
 	return fmt.Sprintf("config: map (%v) not found", e.MapName)
 }
 
+type ErrParamTokenReserved struct {
+	MapName   string
+	Parameter QueryParameter
+}
+
+func (e ErrParamTokenReserved) Error() string {
+	return fmt.Sprintf("config: map %s has parameter %s referencing reserved token %s",
+		e.MapName, e.Parameter.Name, e.Parameter.Token)
+}
+
+type ErrParamNameDuplicate struct {
+	MapName   string
+	Parameter QueryParameter
+}
+
+func (e ErrParamNameDuplicate) Error() string {
+	return fmt.Sprintf("config: map %s redeclares duplicate parameter with name %s",
+		e.MapName, e.Parameter.Name)
+}
+
+type ErrParamTokenDuplicate struct {
+	MapName   string
+	Parameter QueryParameter
+}
+
+func (e ErrParamTokenDuplicate) Error() string {
+	return fmt.Sprintf("config: map %s redeclares existing parameter token %s in param %s",
+		e.MapName, e.Parameter.Token, e.Parameter.Name)
+}
+
 type ErrInvalidProviderForMap struct {
 	MapName      string
 	ProviderName string

--- a/provider/gpkg/gpkg_register.go
+++ b/provider/gpkg/gpkg_register.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	conf "github.com/go-spatial/tegola/config"
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/go-spatial/geom"
@@ -159,6 +160,7 @@ func extractColDefsFromSQL(sql string) []string {
 func featureTableMetaData(gpkg *sql.DB) (map[string]featureTableDetails, error) {
 	// this query is used to read the metadata from the gpkg_contents, gpkg_geometry_columns, and
 	// sqlite_master tables for tables that store geographic features.
+	//goland:noinspection SqlResolve
 	qtext := `
 		SELECT
 			c.table_name, c.min_x, c.min_y, c.max_x, c.max_y, c.srs_id, gc.column_name, gc.geometry_type_name, sm.sql
@@ -335,22 +337,22 @@ func NewTileProvider(config dict.Dicter) (provider.Tiler, error) {
 			// solution without using an SQL parser on custom SQL statements
 			allZoomsSQL := "IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24)"
 			tokenReplacer := strings.NewReplacer(
-				">= "+zoomToken, allZoomsSQL,
-				">="+zoomToken, allZoomsSQL,
-				"=> "+zoomToken, allZoomsSQL,
-				"=>"+zoomToken, allZoomsSQL,
-				"=< "+zoomToken, allZoomsSQL,
-				"=<"+zoomToken, allZoomsSQL,
-				"<= "+zoomToken, allZoomsSQL,
-				"<="+zoomToken, allZoomsSQL,
-				"!= "+zoomToken, allZoomsSQL,
-				"!="+zoomToken, allZoomsSQL,
-				"= "+zoomToken, allZoomsSQL,
-				"="+zoomToken, allZoomsSQL,
-				"> "+zoomToken, allZoomsSQL,
-				">"+zoomToken, allZoomsSQL,
-				"< "+zoomToken, allZoomsSQL,
-				"<"+zoomToken, allZoomsSQL,
+				">= "+conf.ZoomToken, allZoomsSQL,
+				">="+conf.ZoomToken, allZoomsSQL,
+				"=> "+conf.ZoomToken, allZoomsSQL,
+				"=>"+conf.ZoomToken, allZoomsSQL,
+				"=< "+conf.ZoomToken, allZoomsSQL,
+				"=<"+conf.ZoomToken, allZoomsSQL,
+				"<= "+conf.ZoomToken, allZoomsSQL,
+				"<="+conf.ZoomToken, allZoomsSQL,
+				"!= "+conf.ZoomToken, allZoomsSQL,
+				"!="+conf.ZoomToken, allZoomsSQL,
+				"= "+conf.ZoomToken, allZoomsSQL,
+				"="+conf.ZoomToken, allZoomsSQL,
+				"> "+conf.ZoomToken, allZoomsSQL,
+				">"+conf.ZoomToken, allZoomsSQL,
+				"< "+conf.ZoomToken, allZoomsSQL,
+				"<"+conf.ZoomToken, allZoomsSQL,
 			)
 
 			customSQL = tokenReplacer.Replace(customSQL)

--- a/provider/gpkg/util.go
+++ b/provider/gpkg/util.go
@@ -6,11 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-spatial/geom"
-)
-
-const (
-	bboxToken = "!BBOX!"
-	zoomToken = "!ZOOM!"
+	"github.com/go-spatial/tegola/config"
 )
 
 func replaceTokens(qtext string, zoom uint, extent *geom.Extent) string {
@@ -34,8 +30,8 @@ func replaceTokens(qtext string, zoom uint, extent *geom.Extent) string {
 	tokenReplacer := strings.NewReplacer(
 		// The BBOX token requires parameters ordered as [maxx, minx, maxy, miny] and checks for overlap.
 		// 	Until support for named parameters, we'll only support one BBOX token per query.
-		bboxToken, fmt.Sprintf("minx <= %v AND maxx >= %v AND miny <= %v AND maxy >= %v", extent.MaxX(), extent.MinX(), extent.MaxY(), extent.MinY()),
-		zoomToken, strconv.FormatUint(uint64(zoom), 10),
+		config.BboxToken, fmt.Sprintf("minx <= %v AND maxx >= %v AND miny <= %v AND maxy >= %v", extent.MaxX(), extent.MinX(), extent.MaxY(), extent.MinY()),
+		config.ZoomToken, strconv.FormatUint(uint64(zoom), 10),
 	)
 
 	return tokenReplacer.Replace(qtext)

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -185,7 +185,7 @@ const (
 )
 
 // isSelectQuery is a regexp to check if a query starts with `SELECT`,
-// case-insensitive and ignoring any preceeding whitespace and SQL comments.
+// case-insensitive and ignoring any preceding whitespace and SQL comments.
 var isSelectQuery = regexp.MustCompile(`(?i)^((\s*)(--.*\n)?)*select`)
 
 // CreateProvider instantiates and returns a new postgis provider or an error.
@@ -443,7 +443,7 @@ func CreateProvider(config dict.Dicter, providerType string) (*Provider, error) 
 	return &p, nil
 }
 
-// ConfigTLS derived from github.com/jackc/pgx configTLS (https://github.com/jackc/pgx/blob/master/conn.go)
+// ConfigTLS is derived from github.com/jackc/pgx configTLS (https://github.com/jackc/pgx/blob/master/conn.go)
 func ConfigTLS(sslMode string, sslKey string, sslCert string, sslRootCert string, cc *pgx.ConnConfig) error {
 
 	switch sslMode {

--- a/provider/postgis/util.go
+++ b/provider/postgis/util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-spatial/geom"
 	"github.com/go-spatial/tegola"
 	"github.com/go-spatial/tegola/basic"
+	"github.com/go-spatial/tegola/config"
 	"github.com/go-spatial/tegola/provider"
 	"github.com/jackc/pgx"
 	"github.com/jackc/pgx/pgtype"
@@ -97,20 +98,6 @@ func genSQL(l *Layer, pool *connectionPoolCollector, tblname string, flds []stri
 	return fmt.Sprintf(sqlTmpl, selectClause, tblname, l.geomField), nil
 }
 
-const (
-	bboxToken             = "!BBOX!"
-	zoomToken             = "!ZOOM!"
-	xToken                = "!X!"
-	yToken                = "!Y!"
-	zToken                = "!Z!"
-	scaleDenominatorToken = "!SCALE_DENOMINATOR!"
-	pixelWidthToken       = "!PIXEL_WIDTH!"
-	pixelHeightToken      = "!PIXEL_HEIGHT!"
-	idFieldToken          = "!ID_FIELD!"
-	geomFieldToken        = "!GEOM_FIELD!"
-	geomTypeToken         = "!GEOM_TYPE!"
-)
-
 // replaceTokens replaces tokens in the provided SQL string
 //
 // !BBOX! - the bounding box of the tile
@@ -169,17 +156,17 @@ func replaceTokens(sql string, lyr *Layer, tile provider.Tile, withBuffer bool) 
 	// replace query string tokens
 	z, x, y := tile.ZXY()
 	tokenReplacer := strings.NewReplacer(
-		bboxToken, bbox,
-		zoomToken, strconv.FormatUint(uint64(z), 10),
-		zToken, strconv.FormatUint(uint64(z), 10),
-		xToken, strconv.FormatUint(uint64(x), 10),
-		yToken, strconv.FormatUint(uint64(y), 10),
-		idFieldToken, lyr.IDFieldName(),
-		geomFieldToken, lyr.GeomFieldName(),
-		geomTypeToken, geoType,
-		scaleDenominatorToken, strconv.FormatFloat(scaleDenominator, 'f', -1, 64),
-		pixelWidthToken, strconv.FormatFloat(pixelWidth, 'f', -1, 64),
-		pixelHeightToken, strconv.FormatFloat(pixelHeight, 'f', -1, 64),
+		config.BboxToken, bbox,
+		config.ZoomToken, strconv.FormatUint(uint64(z), 10),
+		config.ZToken, strconv.FormatUint(uint64(z), 10),
+		config.XToken, strconv.FormatUint(uint64(x), 10),
+		config.YToken, strconv.FormatUint(uint64(y), 10),
+		config.ScaleDenominatorToken, strconv.FormatFloat(scaleDenominator, 'f', -1, 64),
+		config.PixelWidthToken, strconv.FormatFloat(pixelWidth, 'f', -1, 64),
+		config.PixelHeightToken, strconv.FormatFloat(pixelHeight, 'f', -1, 64),
+		config.IdFieldToken, lyr.IDFieldName(),
+		config.GeomFieldToken, lyr.GeomFieldName(),
+		config.GeomTypeToken, geoType,
 	)
 
 	uppercaseTokenSQL := uppercaseTokens(sql)

--- a/server/handle_map_layer_zxy.go
+++ b/server/handle_map_layer_zxy.go
@@ -165,9 +165,16 @@ func (req HandleMapLayerZXY) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err = r.ParseForm()
 		if err == nil {
 			for _, param := range req.Atlas.GetParams(req.mapName) {
+				// Fetch parameter values
 				val := r.Form.Get(param.Name)
-				// empty values are injected here to replace tokens with
+				// Empty values are injected here to replace tokens with
 				// an empty string during sql query parameter replacement
+				// otherwise, the default value is used if configured.
+				if val == "" && param.Default != "" {
+					val = param.Default
+				}
+
+				// inject parameter value or default into params map
 				params[param.Token] = val
 			}
 


### PR DESCRIPTION
Hi all. I recently stumbled upon a use-case for having query parameters present in URLs. Being able to configure Tegola's queries on the fly with optional URL query parameters for filtering down data can simplify configuration for large datasets that would otherwise have many layers defined manually.

Defining a query parameter is as simple as this:
```toml
[[maps.params]]
name = "param"
token = "!PARAM!"
default = "7"
```

This will configure a parameter named `param` with the SQL replacement token `!PARAM!`. The `default` key is optional and allows you to specify a default value for the parameter if none is provided. Without a default specified, the replacer will default to substituting an empty string.

The endpoint then becomes queryable at:
```
http://server:8080/maps/example/{z}/{x}/{y}.pbf?param=123
```

Currently, to prevent SQL injection, parameter values are limited to values matching the following regular expression. This is to limit control characters from being injected via query parameters:
```regex
[a-zA-Z0-9,._-]+
```

This obviously needs more work and I am open to feedback regarding security. I've also thought of limiting the scope of query parameters to integers only since most of the use cases I've found for this feature involve numeric ID matching in queries.

Any and all feedback is welcome. I hope others can find value in this contribution.