### PR TITLE
config: read config from stdin

### DIFF
--- a/cmd/tegola/cmd/root.go
+++ b/cmd/tegola/cmd/root.go
@@ -24,7 +24,8 @@ var (
 
 func init() {
 	// root
-	RootCmd.PersistentFlags().StringVar(&configFile, "config", "config.toml", "path to config file")
+	RootCmd.PersistentFlags().StringVar(&configFile, "config", "config.toml",
+		"path or http url to a config file, or \"-\" for stdin")
 
 	// server
 	serverCmd.Flags().StringVarP(&serverPort, "port", "p", ":8080", "port to bind tile server to")

--- a/config/config.go
+++ b/config/config.go
@@ -302,6 +302,9 @@ func Load(location string) (conf Config, err error) {
 
 		// set the reader to the response body
 		reader = res.Body
+	} else if location == "-" {
+		log.Infof("loading local config from stdin")
+		reader = os.Stdin
 	} else {
 		log.Infof("loading local config (%v)", location)
 


### PR DESCRIPTION
This feature is helpful for running configs generated from another command (like `dhall-toml` 👀).

The `-` is an idiomatic alias for stdin used in commands like `curl` and `grep`.