### PR TITLE
Added file.Close() call to file cache Get() method

### DIFF
--- a/cache/file/file.go
+++ b/cache/file/file.go
@@ -82,6 +82,7 @@ func (fc *Cache) Get(key *cache.Key) ([]byte, bool, error) {
 
 		return nil, false, err
 	}
+	defer f.Close()
 
 	val, err := ioutil.ReadAll(f)
 	if err != nil {


### PR DESCRIPTION
The Get() method for the file cache was not closing files
that it opened. This will eventually cause an issue with
too many file descriptors being open.

closes #586