### PR TITLE
feat: redis ssl in cache options

### DIFF
--- a/cache/redis/errors.go
+++ b/cache/redis/errors.go
@@ -1,0 +1,10 @@
+package redis
+
+// ErrHostMissing is raised when Redis Addr is missing Host
+type ErrHostMissing struct {
+	msg string
+}
+
+func (error *ErrHostMissing) Error() string {
+	return error.msg
+}


### PR DESCRIPTION
As discussed in #815 I create a new option for redis. I follow your implementation to the point where I check if `ssl` is true. If it's the case I split the `addr` into host and port and create a `tls.Config`. I follow [`ParseURL`](https://github.com/go-redis/redis/blob/16ab0f2ac309166bfef5cde51742f84c61c1e73c/options.go#L211) implementation here and add a TLSConfig to the `redis.Options`.