### PR TITLE
fix: gen_version job missing checkout action

### DIFF
--- a/.github/workflows/on_release_publish.yml
+++ b/.github/workflows/on_release_publish.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
     # on release we want to use release.tag_name for the version
     - name: Set tegola version (use release.tag_name)
       if: github.event_name == 'release'


### PR DESCRIPTION
The gen_version job is missing the code checkout. Therefor getting the default branch errors out with

```
fatal: not a git repository (or any of the parent directories): .git
```