### PR TITLE
chore: add docker-compose local dev env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+# this file is used to bootstrap services to run tegola tests against
+version: "3"
+
+services:
+  redis:
+    image: redis:6.2.6
+    container_name: redis
+    ports:
+      - 6379:6379
+
+  postgis:
+    image: postgis/postgis:12-3.0-alpine
+    container_name: postgis
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - 5432:5432
+
+  migration:
+    image: postgis/postgis:12-3.0-alpine
+    container_name: migration
+    depends_on:
+      postgis:
+        condition: service_healthy
+    environment:
+      PGUSER: postgres
+      PGPASSWORD: postgres
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        wget "https://github.com/go-spatial/tegola-testdata/raw/master/tegola.dump" 
+        psql -h postgis -p 5432 -U postgres -d postgres -c "DROP DATABASE IF EXISTS tegola;"
+        pg_restore -h postgis -p 5432 -U postgres -d postgres -C tegola.dump
+        psql -h postgis -U postgres -d postgres -c "DROP ROLE IF EXISTS tegola_no_access;CREATE ROLE tegola_no_access LOGIN PASSWORD 'postgres'"
+        rm tegola.dump
+
+

--- a/provider/postgis/util_internal_test.go
+++ b/provider/postgis/util_internal_test.go
@@ -125,7 +125,7 @@ func TestDecipherFields(t *testing.T) {
 	}
 
 	host := os.Getenv("PGHOST")
-	port := 5432
+	port := os.Getenv("PGPORT")
 	db := os.Getenv("PGDATABASE")
 	user := os.Getenv("PGUSER")
 	password := os.Getenv("PGPASSWORD")


### PR DESCRIPTION
This PR adds a local development environment using [docker compose](https://docs.docker.com/compose/) as proposed [here](https://gophers.slack.com/archives/C9LA1F8F8/p1646922370441369) that makes local development a breeze, even if you're unfamiliar with the project.

1. clone the repository
2. `docker compose up`
3. run test suite
```
RUN_POSTGIS_TESTS=yes RUN_REDIS_TESTS=yes PGSSLMODE=disable PGSSLKEY="" PGSSLCERT="" PGSSLROOTCERT="" PGHOST=localhost PGPORT=5432 PGDATABASE=tegola PGUSER=postgres PGPASSWORD=postgres PGUSER_NO_ACCESS=tegola_no_access go test  ./... -v
```
4. `docker compose down`