### PR TITLE
feat: allow connection URI and add additional config parameters

### DIFF
--- a/provider/postgis/README.md
+++ b/provider/postgis/README.md
@@ -6,24 +6,60 @@ The PostGIS provider manages querying for tile requests against a Postgres datab
 [[providers]]
 name = "test_postgis"       # provider name is referenced from map layers (required)
 type = "postgis"            # the type of data provider must be "postgis" for this data provider (required)
-host = "localhost"          # PostGIS database host (required)
-port = 5432                 # PostGIS database port (required)
-database = "tegola"         # PostGIS database name (required)
-user = "tegola"             # PostGIS database user (required)
-password = ""               # PostGIS database password (required)
+
+uri = "postgres://tegola:supersecret@localhost:5432/tegola?sslmode=prefer" # PostGIS connection string (required)
+
+host = "localhost"                # PostGIS database host (deprecated)
+port = 5432                       # PostGIS database port (deprecated)
+database = "tegola"               # PostGIS database name (deprecated)
+user = "tegola"                   # PostGIS database user (deprecated)
+password = "supersecret"          # PostGIS database password (deprecated)
+max_connections = 10              # PostGIS max connections (deprecated)
+max_connection_idle_time = "30m"  # PostGIS max connection idle time (deprecated)
+max_connection_lifetime = "1h"    # PostGIS max connection life time (deprecated)
 ```
 
 ### Connection Properties
 
+Establishing a connection via connection string (`uri`) will become the default connection method as of v0.16.0.
+Connecting via host/port/database is flagged for deprecation as of v0.15.0 but will be possible until v0.16.0 still.
+
+- `uri` (string): [Required] PostGIS connection string
 - `name` (string): [Required] provider name is referenced from map layers
 - `type` (string): [Required] the type of data provider. must be "postgis" to use this data provider
-- `host` (string): [Required] PostGIS database host
-- `port` (int): [Required] PostGIS database port (required)
-- `database` (string): [Required] PostGIS database name
-- `user` (string): [Required] PostGIS database user
-- `password` (string): [Required] PostGIS database password
 - `srid` (int): [Optional] The default SRID for the provider. Defaults to WebMercator (3857) but also supports WGS84 (4326)
-- `max_connections` (int): [Optional] The max connections to maintain in the connection pool. Defaults to 100. 0 means no max.
+
+#### Connection string properties
+
+**Example**
+
+```
+# {protocol}://{user}:{password}@{host}:{port}/{database}?{options}=
+postgres://tegola:supersecret@localhost:5432/tegola?sslmode=prefer&pool_max_conns=10
+```
+
+**Options**
+
+- `sslmode`: [Optional] PostGIS SSL mode. Default: "prefer"
+- `pool_max_conns`: [Optional] The max connections to maintain in the connection pool. Defaults to 100. 0 means no max.
+- `pool_max_conn_idle_time`: [Optional] The maximum time an idle connection is kept alive. Defaults to "30m".
+- `max_connection_lifetime` [Optional] The maximum time a connection lives before it is terminated and recreated. Defaults to "1h".
+
+### [DEPRECATED] Connection Properties
+
+- `uri` (string): [Required] PostGIS connection string
+- `name` (string): [Required] provider name is referenced from map layers
+- `type` (string): [Required] the type of data provider. must be "postgis" to use this data provider
+- `host` (string): [deprecated] PostGIS database host
+- `port` (int): [deprecated] PostGIS database port (required)
+- `database` (string): [deprecated] PostGIS database name
+- `user` (string): [deprecated] PostGIS database user
+- `password` (string): [deprecated] PostGIS database password
+- `srid` (int): [Optional] The default SRID for the provider. Defaults to WebMercator (3857) but also supports WGS84 (4326)
+- `ssl_mode`: (string): [Optional]. PostGIS SSL mode. Default is "prefer".
+- `max_connections` (int): [deprecated] The max connections to maintain in the connection pool. Defaults to 100. 0 means no max.
+- `max_connection_idle_time` (duration string): [deprecated] The maximum time an idle connection is kept alive.
+- `max_connection_lifetime` (duration string): [deprecated] The maximum time a connection lives before it is terminated and recreated.
 
 ## Provider Layers
 In addition to the connection configuration above, Provider Layers need to be configured. A Provider Layer tells tegola how to query PostGIS for a certain layer. An example minimum config:

--- a/provider/postgis/error.go
+++ b/provider/postgis/error.go
@@ -37,3 +37,24 @@ type ErrGeomFieldNotFound struct {
 func (e ErrGeomFieldNotFound) Error() string {
 	return fmt.Sprintf("postgis: geom fieldname (%v) not found for layer (%v)", e.GeomFieldName, e.LayerName)
 }
+
+type ErrInvalidURI struct {
+	Err error
+	Msg string
+}
+
+func (e ErrInvalidURI) Error() string {
+	if e.Msg == "" {
+		if e.Err != nil {
+			return fmt.Sprintf("postgis: %v", e.Err.Error())
+		} else {
+			return "postgis: invalid uri"
+		}
+	}
+
+	return fmt.Sprintf("postgis: invalid uri (%v)", e.Msg)
+}
+
+func (e ErrInvalidURI) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
Hi 👋 

Now with the new pgx it is easier to pass a connection string which was on the wishlist for some issues (eg. #774). If the `uri` is set in the `config.toml` said `uri` is used without compromise as long as the basic information `user`, `password`, `host`, `port` and `database` are set. The `sslmode` is added if not specifically set.

Something on my personal wish list was the addition of  `"max_connection_idle_time"` and `"max_connection_lifetime"` to the config that default to the [pgx default](https://github.com/jackc/pgx/blob/3ce50c079e874c87c4d53eada409738d8504bac6/pgxpool/pool.go#L18) if not specifically set.

