### PR TITLE
fix: replace environment variables in webserver headers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -275,10 +275,15 @@ func (c *Config) ConfigureTileBuffers() {
 func Parse(reader io.Reader, location string) (conf Config, err error) {
 	// decode conf file, don't care about the meta data.
 	_, err = toml.DecodeReader(reader, &conf)
+	if err != nil {
+		return conf, err
+	}
+
 	conf.LocationName = location
+
 	conf.ConfigureTileBuffers()
 
-	return conf, err
+	return conf, nil
 }
 
 // Load will load and parse the config file from the given location.

--- a/internal/env/parse.go
+++ b/internal/env/parse.go
@@ -237,3 +237,38 @@ func ParseFloatSlice(val string) ([]float64, error) {
 
 	return floats, nil
 }
+
+func ParseDict(v interface{}) (*Dict, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	var d = make(Dict)
+
+	switch val := v.(type) {
+	case map[string]interface{}:
+		for k, v := range val {
+			switch v.(type) {
+			case string:
+				s, err := ParseString(v)
+				if err != nil {
+					return nil, err
+				}
+
+				d[k] = *s
+			case map[string]interface{}:
+				i, err := ParseDict(v)
+				if err != nil {
+					return nil, err
+				}
+				d[k] = *i
+			default:
+				d[k] = v
+			}
+		}
+	default:
+		return nil, ErrType{v}
+	}
+
+	return &d, nil
+}

--- a/internal/env/types.go
+++ b/internal/env/types.go
@@ -53,6 +53,20 @@ func replaceEnvVar(in string) (string, error) {
 
 //TODO(@ear7h): implement UnmarshalJSON for types
 
+func (t *Dict) UnmarshalTOML(v interface{}) error {
+	var d *Dict
+	var err error
+
+	d, err = ParseDict(v)
+	if err != nil {
+		return err
+	}
+
+	*t = *d
+
+	return nil
+}
+
 type Bool bool
 
 func BoolPtr(v Bool) *Bool {


### PR DESCRIPTION
Using environment variables in `config.Webserver.Headers` would not replace environment variables currently. I therefore added an additional step in `config.Parse` that would iterate over the header and resolve the environment variables if possible. I opted to otherwise raise if the environment variable is not present similar to the behaviour we have right now if any other env is missing. This could also just handle the error and use the original value.

I updated the tests accordingly and added some more to test in isolation. 

As mentioned on slack I'm not sure if that is the correct spot to fix it, so your input is greatly appreciated as usual. :)