### PR TITLE
Add a dont_clean option

### DIFF
--- a/atlas/layer.go
+++ b/atlas/layer.go
@@ -17,13 +17,13 @@ type Layer struct {
 	// default tags to include when encoding the layer. provider tags take precedence
 	DefaultTags map[string]interface{}
 	GeomType    geom.Geometry
-	// DontSimplify indicates wheather feature simplification should be applied.
+	// DontSimplify indicates whether feature simplification should be applied.
 	// We use a negative in the name so the default is to simplify
 	DontSimplify bool
-	// DontClip indicates wheather feature clipping should be applied.
+	// DontClip indicates whether feature clipping should be applied.
 	// We use a negative in the name so the default is to clip
 	DontClip bool
-	// DontClean indicates wheather feature cleaning (e.g. make valid) should be applied.
+	// DontClean indicates whether feature cleaning (e.g. make valid) should be applied.
 	// We use a negative in the name so the default is to clean
 	DontClean bool
 }

--- a/atlas/layer.go
+++ b/atlas/layer.go
@@ -23,6 +23,9 @@ type Layer struct {
 	// DontClip indicates wheather feature clipping should be applied.
 	// We use a negative in the name so the default is to clip
 	DontClip bool
+	// DontClean indicates wheather feature cleaning (e.g. make valid) should be applied.
+	// We use a negative in the name so the default is to clean
+	DontClean bool
 }
 
 // MVTName will return the value that will be encoded in the Name field when the layer is encoded as MVT

--- a/atlas/map.go
+++ b/atlas/map.go
@@ -300,9 +300,13 @@ func (m Map) encodeMVTTile(ctx context.Context, tile *slippy.Tile) ([]byte, erro
 					return err
 				}
 
-				tegolaGeo, err = validate.CleanGeometry(ctx, sg, clipRegion)
-				if err != nil {
-					return fmt.Errorf("err making geometry valid: %w", err)
+				if !l.DontClean {
+					tegolaGeo, err = validate.CleanGeometry(ctx, sg, clipRegion)
+					if err != nil {
+						return fmt.Errorf("err making geometry valid: %w", err)
+					}
+				} else {
+					tegolaGeo = sg
 				}
 
 				geo, err = convert.ToGeom(tegolaGeo)

--- a/cmd/internal/register/maps.go
+++ b/cmd/internal/register/maps.go
@@ -88,6 +88,7 @@ func atlasLayerFromConfigLayer(cfg *config.MapLayer, mapName string, layerProvid
 	layer.ProviderLayerName = layerName
 	layer.DontSimplify = bool(cfg.DontSimplify)
 	layer.DontClip = bool(cfg.DontClip)
+	layer.DontClean = bool(cfg.DontClean)
 
 	if cfg.MinZoom != nil {
 		layer.MinZoom = uint(*cfg.MinZoom)

--- a/config/config.go
+++ b/config/config.go
@@ -75,6 +75,9 @@ type MapLayer struct {
 	// DontClip indicates wheather feature clipping should be applied.
 	// We use a negative in the name so the default is to clipping
 	DontClip env.Bool `toml:"dont_clip"`
+	// DontClip indicates wheather feature cleaning (e.g. make valid) should be applied.
+	// We use a negative in the name so the default is to clean
+	DontClean env.Bool `toml:"dont_clean"`
 }
 
 // ProviderLayerName returns the names of the layer and provider or an error

--- a/config/config.go
+++ b/config/config.go
@@ -69,13 +69,13 @@ type MapLayer struct {
 	MinZoom       *env.Uint   `toml:"min_zoom"`
 	MaxZoom       *env.Uint   `toml:"max_zoom"`
 	DefaultTags   interface{} `toml:"default_tags"`
-	// DontSimplify indicates wheather feature simplification should be applied.
+	// DontSimplify indicates whether feature simplification should be applied.
 	// We use a negative in the name so the default is to simplify
 	DontSimplify env.Bool `toml:"dont_simplify"`
-	// DontClip indicates wheather feature clipping should be applied.
+	// DontClip indicates whether feature clipping should be applied.
 	// We use a negative in the name so the default is to clipping
 	DontClip env.Bool `toml:"dont_clip"`
-	// DontClip indicates wheather feature cleaning (e.g. make valid) should be applied.
+	// DontClip indicates whether feature cleaning (e.g. make valid) should be applied.
 	// We use a negative in the name so the default is to clean
 	DontClean env.Bool `toml:"dont_clean"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -139,7 +139,8 @@ func TestParse(t *testing.T) {
 					min_zoom = 10
 					max_zoom = 20
 					dont_simplify = true
-					dont_clip = true`,
+					dont_clip = true
+					dont_clean = true`,
 			expected: config.Config{
 				TileBuffer:   env.IntPtr(env.Int(12)),
 				LocationName: "",
@@ -188,6 +189,7 @@ func TestParse(t *testing.T) {
 								MaxZoom:       env.UintPtr(20),
 								DontSimplify:  true,
 								DontClip:      true,
+								DontClean:     true,
 							},
 						},
 					},

--- a/maths/validate/validate.go
+++ b/maths/validate/validate.go
@@ -98,7 +98,7 @@ func scaleMultiPolygon(p tegola.MultiPolygon, factor float64) (bmp basic.MultiPo
 	return bmp
 }
 
-// CleanGeometry will apply various geoprocessing algorithems to the provided geometry.
+// CleanGeometry will apply various geoprocessing algorithms to the provided geometry.
 // the extent will be used as a clipping region. if no clipping is desired, pass in a nil extent.
 func CleanGeometry(ctx context.Context, g tegola.Geometry, extent *geom.Extent) (geo tegola.Geometry, err error) {
 	if g == nil {


### PR DESCRIPTION
We have a use case with a very large (85+ GiB, 20+ layers) dataset with small features that only need to be served on one zoom level. "Small" means that the features are usually not bigger than 1 tile in the single zoomlevel that they are served on. The features in the dataset are validated beforehand (self intersecting, etc). Clipping, simplifying and cleaning/validating are not necessary in our case, and disabling them increases performance. Especially cleaning takes a lot of processing time, which takes the response time above a workable threshold for this dataset. (Especially when clipping is disabled, but that's a [known issue](https://github.com/go-spatial/tegola/blob/v0.15.x/atlas/map.go#L290), I believe.)

tl;dr: an option to disable cleaning/making valid