### PR TITLE
test: add a ttools helper for easier local testing

### DIFF
--- a/internal/ttools/getenv.go
+++ b/internal/ttools/getenv.go
@@ -1,0 +1,16 @@
+package ttools
+
+import (
+	"os"
+)
+
+// GetEnvDefault looks up an environment variable, and return a default value
+// when it is not present
+func GetEnvDefault(key, dvalue string) string {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return dvalue
+	}
+
+	return v
+}

--- a/internal/ttools/getenv_test.go
+++ b/internal/ttools/getenv_test.go
@@ -1,0 +1,70 @@
+package ttools
+
+import (
+	"os"
+	"testing"
+)
+
+const (
+	ENV_TEST_VARIABLE       = "test"
+	ENV_TEST_EMPTY_VARIABLE = ""
+)
+
+func setEnv() {
+	os.Setenv("ENV_TEST_VARIABLE", ENV_TEST_VARIABLE)
+	os.Setenv("ENV_TEST_EMPTY_VARIABLE", ENV_TEST_EMPTY_VARIABLE)
+}
+
+func unsetEnv() {
+	os.Unsetenv("ENV_TEST_VARIABLE")
+	os.Unsetenv("ENV_TEST_EMPTY_VARIABLE")
+}
+
+func TestGetEnvDefault(t *testing.T) {
+	type tcase struct {
+		key      string
+		dvalue   string
+		expected string
+	}
+
+	setEnv()
+	defer unsetEnv()
+
+	fn := func(tc tcase) func(*testing.T) {
+		return func(t *testing.T) {
+
+			v := GetEnvDefault(tc.key, tc.dvalue)
+
+			if v != tc.expected {
+				t.Errorf("\n\nexpected: %s \ngot: %s \n\n", tc.expected, v)
+			}
+		}
+	}
+
+	tests := map[string]tcase{
+		"should use default value": {
+			key:      "ENV_THAT_DOESNT_EXIST",
+			dvalue:   "DEFAULT_VALUE",
+			expected: "DEFAULT_VALUE",
+		},
+		"should get variable from environment": {
+			key:      "ENV_TEST_VARIABLE",
+			dvalue:   "DEFAULT_VALUE",
+			expected: ENV_TEST_VARIABLE,
+		},
+		"should use default when key is empty string": {
+			key:      "",
+			dvalue:   "DEFAULT_VALUE",
+			expected: "DEFAULT_VALUE",
+		},
+		"should get variable from empty string environment": {
+			key:      "ENV_TEST_EMPTY_VARIABLE",
+			dvalue:   "DEFAULT_VALUE",
+			expected: ENV_TEST_EMPTY_VARIABLE,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, fn(tc))
+	}
+}

--- a/provider/postgis/util_internal_test.go
+++ b/provider/postgis/util_internal_test.go
@@ -3,7 +3,7 @@ package postgis
 import (
 	"context"
 	"fmt"
-	"os"
+	"strconv"
 	"testing"
 
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -124,11 +124,15 @@ func TestDecipherFields(t *testing.T) {
 		expectedTags     map[string]interface{}
 	}
 
-	host := os.Getenv("PGHOST")
-	port := os.Getenv("PGPORT")
-	db := os.Getenv("PGDATABASE")
-	user := os.Getenv("PGUSER")
-	password := os.Getenv("PGPASSWORD")
+	host := ttools.GetEnvDefault("PGHOST", "localhost")
+	port, err := strconv.Atoi(ttools.GetEnvDefault("PGPORT", "5432"))
+	// if port is anything but int, fallback to default
+	if err != nil {
+		port = 5432
+	}
+	db := ttools.GetEnvDefault("PGDATABASE", "tegola")
+	user := ttools.GetEnvDefault("PGUSER", "postgres")
+	password := ttools.GetEnvDefault("PGPASSWORD", "postgres")
 
 	cs := fmt.Sprintf("postgres://%v:%v@%v:%v/%v", user, password, host, port, db)
 	dbconfig, err := BuildDBConfig(cs)


### PR DESCRIPTION
More than once I stumble upon this during testing. Previously a local test required to setup the local development environment and passing a bunch of environment variables prior to running `go test ./...`. 

```
docker compose up

RUN_POSTGIS_TESTS=yes \ 
RUN_REDIS_TESTS=yes \ 
PGSSLMODE=disable \ 
PGSSLKEY="" \ 
PGSSLCERT="" \ 
PGSSLROOTCERT="" \
PGHOST=localhost \
PGPORT=5432 \
PGDATABASE=tegola \
PGUSER=postgres \
PGPASSWORD=postgres \
PGUSER_NO_ACCESS=tegola_no_access \
go test  ./... -v
```

Now we allow for environment variables to be passed, but also default back to variables we used across tests and pipelines as default, making testing a little more comfy.

```
RUN_POSTGIS_TESTS=yes \ 
RUN_REDIS_TESTS=yes \ 
go test  ./... -v
```

wdyt?