### PR TITLE
fix: filter by zoom level for min/max zoom 0

### DIFF
--- a/atlas/map.go
+++ b/atlas/map.go
@@ -145,7 +145,7 @@ func (m Map) FilterLayersByZoom(zoom uint) Map {
 	var layers []Layer
 
 	for i := range m.Layers {
-		if (m.Layers[i].MinZoom <= zoom || m.Layers[i].MinZoom == 0) && (m.Layers[i].MaxZoom >= zoom || m.Layers[i].MaxZoom == 0) {
+		if m.Layers[i].MinZoom <= zoom && m.Layers[i].MaxZoom >= zoom {
 			layers = append(layers, m.Layers[i])
 			continue
 		}

--- a/atlas/map_test.go
+++ b/atlas/map_test.go
@@ -81,6 +81,58 @@ func TestMapFilterLayersByZoom(t *testing.T) {
 				},
 			},
 		},
+		{
+			atlasMap: atlas.Map{
+				Layers: []atlas.Layer{
+					{
+						Name:    "layer1",
+						MinZoom: 0,
+						MaxZoom: 0,
+					},
+					{
+						Name:    "layer2",
+						MinZoom: 1,
+						MaxZoom: 5,
+					},
+				},
+			},
+			zoom: 2,
+			expected: atlas.Map{
+				Layers: []atlas.Layer{
+					{
+						Name:    "layer2",
+						MinZoom: 1,
+						MaxZoom: 5,
+					},
+				},
+			},
+		},
+		{
+			atlasMap: atlas.Map{
+				Layers: []atlas.Layer{
+					{
+						Name:    "layer1",
+						MinZoom: 0,
+						MaxZoom: 0,
+					},
+					{
+						Name:    "layer2",
+						MinZoom: 1,
+						MaxZoom: 5,
+					},
+				},
+			},
+			zoom: 0,
+			expected: atlas.Map{
+				Layers: []atlas.Layer{
+					{
+						Name:    "layer1",
+						MinZoom: 0,
+						MaxZoom: 0,
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testcases {


### PR DESCRIPTION
Prior to this, setting min_zoom=0 and max_zoom=0 would result
in the layer being present across the entire zoom range.

Should fix #870 