### PR TITLE
feat: parameter to control tile logging during seeding

### DIFF
--- a/cmd/tegola/cmd/cache/seed_purge.go
+++ b/cmd/tegola/cmd/cache/seed_purge.go
@@ -49,6 +49,8 @@ var (
 	cacheBounds string
 	// name of the map
 	cacheMap string
+	// while seeding, on log output for tiles that take longer than this (in milliseconds) to render
+	cacheLogThreshold int64
 )
 
 // variables that are not flags but set by the command.
@@ -71,6 +73,7 @@ func init() {
 	SeedPurgeCmd.PersistentFlags().StringVarP(&cacheMap, "map", "", "", "map name as defined in the config")
 	SeedPurgeCmd.PersistentFlags().IntVarP(&cacheConcurrency, "concurrency", "", runtime.NumCPU(), "the amount of concurrency to use. defaults to the number of CPUs on the machine")
 	SeedPurgeCmd.PersistentFlags().BoolVarP(&cacheOverwrite, "overwrite", "", false, "overwrite the cache if a tile already exists (default false)")
+	SeedPurgeCmd.PersistentFlags().Int64VarP(&cacheLogThreshold, "log-threshold", "", 0, "during seeding, only log tiles that take this number of milliseconds or longer to render (default all tiles)")
 
 	SeedPurgeCmd.Flags().StringVarP(&cacheBounds, "bounds", "", "-180,-85.0511,180,85.0511", "lng/lat bounds to seed the cache with in the format: minx, miny, maxx, maxy")
 
@@ -128,7 +131,7 @@ func seedPurgeCmdValidatePersistent(cmd *cobra.Command, args []string) error {
 	case "purge":
 		seedPurgeWorker = purgeWorker
 	case "seed":
-		seedPurgeWorker = seedWorker(cacheOverwrite)
+		seedPurgeWorker = seedWorker(cacheOverwrite, cacheLogThreshold)
 	default:
 
 		return fmt.Errorf("expected purge/seed got (%v) for command name", cmdName)

--- a/cmd/tegola/cmd/cache/worker.go
+++ b/cmd/tegola/cmd/cache/worker.go
@@ -27,7 +27,7 @@ func (s seedPurgeWorkerTileError) Error() string {
 	return fmt.Sprintf("error %v tile (%+v): %v", cmd, s.Tile, s.Err)
 }
 
-func seedWorker(overwrite bool) func(ctx context.Context, mt MapTile) error {
+func seedWorker(overwrite bool, logThresholdMs int64) func(ctx context.Context, mt MapTile) error {
 	return func(ctx context.Context, mt MapTile) error {
 		// track how long the tile generation is taking
 		t := time.Now()
@@ -89,7 +89,10 @@ func seedWorker(overwrite bool) func(ctx context.Context, mt MapTile) error {
 		//	https://github.com/golang/go/issues/14045 - should be addressed in Go 1.11
 		runtime.GC()
 
-		log.Infof("seeding map (%v) tile (%v/%v/%v) took: %dms", mt.MapName, z, x, y, time.Now().Sub(t).Nanoseconds()/1000000)
+		durationMs := time.Now().Sub(t).Nanoseconds()/1000000
+		if durationMs >= logThresholdMs {
+			log.Infof("seeding map (%v) tile (%v/%v/%v) took: %dms", mt.MapName, z, x, y, durationMs)
+		}
 
 		return nil
 	}


### PR DESCRIPTION
This PR adds a `--log-threshold int` command line argument to the `seed` command to limit which tiles produce logs when rendered. Tiles that render in less than `int` milliseconds will not produce logging output. The default value is 0, at which all tiles rendered will be logged.

My goal here is to reduce noise and get a better sense of which zoom levels actually need to be cached (as opposed to rendered on the fly).

Fixes #878