### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"errors"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -30,33 +29,22 @@ const (
 	ENV_TEST_MAP_LAYER_DEFAULT_TAG   = "postgis"
 )
 
-func setEnv() {
+func setEnv(t *testing.T) {
 	x := strconv.FormatFloat(ENV_TEST_CENTER_X, 'f', -1, 64)
 	y := strconv.FormatFloat(ENV_TEST_CENTER_Y, 'f', -1, 64)
 	z := strconv.FormatFloat(ENV_TEST_CENTER_Z, 'f', -1, 64)
 
-	os.Setenv("ENV_TEST_PORT", ENV_TEST_PORT)
-	os.Setenv("ENV_TEST_CENTER_X", x)
-	os.Setenv("ENV_TEST_CENTER_Y", y)
-	os.Setenv("ENV_TEST_CENTER_Z", z)
-	os.Setenv("ENV_TEST_HOST_1", ENV_TEST_HOST_1)
-	os.Setenv("ENV_TEST_HOST_2", ENV_TEST_HOST_2)
-	os.Setenv("ENV_TEST_HOST_3", ENV_TEST_HOST_3)
-	os.Setenv("ENV_TEST_WEBSERVER_HEADER_STRING", ENV_TEST_WEBSERVER_HEADER_STRING)
-	os.Setenv("ENV_TEST_WEBSERVER_PORT", ENV_TEST_WEBSERVER_PORT)
-	os.Setenv("ENV_TEST_PROVIDER_LAYER", ENV_TEST_PROVIDER_LAYER)
-	os.Setenv("ENV_TEST_MAP_LAYER_DEFAULT_TAG", ENV_TEST_MAP_LAYER_DEFAULT_TAG)
-}
-
-func unsetEnv() {
-	os.Unsetenv("ENV_TEST_PORT")
-	os.Unsetenv("ENV_TEST_CENTER_X")
-	os.Unsetenv("ENV_TEST_CENTER_Y")
-	os.Unsetenv("ENV_TEST_CENTER_Z")
-	os.Unsetenv("ENV_TEST_WEBSERVER_HEADER_STRING")
-	os.Unsetenv("ENV_TEST_WEBSERVER_PORT")
-	os.Unsetenv("ENV_TEST_PROVIDER_LAYER")
-	os.Unsetenv("ENV_TEST_MAP_LAYER_DEFAULT_TAG")
+	t.Setenv("ENV_TEST_PORT", ENV_TEST_PORT)
+	t.Setenv("ENV_TEST_CENTER_X", x)
+	t.Setenv("ENV_TEST_CENTER_Y", y)
+	t.Setenv("ENV_TEST_CENTER_Z", z)
+	t.Setenv("ENV_TEST_HOST_1", ENV_TEST_HOST_1)
+	t.Setenv("ENV_TEST_HOST_2", ENV_TEST_HOST_2)
+	t.Setenv("ENV_TEST_HOST_3", ENV_TEST_HOST_3)
+	t.Setenv("ENV_TEST_WEBSERVER_HEADER_STRING", ENV_TEST_WEBSERVER_HEADER_STRING)
+	t.Setenv("ENV_TEST_WEBSERVER_PORT", ENV_TEST_WEBSERVER_PORT)
+	t.Setenv("ENV_TEST_PROVIDER_LAYER", ENV_TEST_PROVIDER_LAYER)
+	t.Setenv("ENV_TEST_MAP_LAYER_DEFAULT_TAG", ENV_TEST_MAP_LAYER_DEFAULT_TAG)
 }
 
 func TestParse(t *testing.T) {
@@ -66,8 +54,7 @@ func TestParse(t *testing.T) {
 		expectedErr error
 	}
 
-	setEnv()
-	defer unsetEnv()
+	setEnv(t)
 
 	fn := func(tc tcase) func(*testing.T) {
 		return func(t *testing.T) {

--- a/internal/env/dict_test.go
+++ b/internal/env/dict_test.go
@@ -1,7 +1,6 @@
 package env_test
 
 import (
-	"os"
 	"reflect"
 	"testing"
 
@@ -22,15 +21,8 @@ func TestDict(t *testing.T) {
 		return func(t *testing.T) {
 			// setup our env vars
 			for k, v := range tc.envVars {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
-
-			// clean up env vars
-			defer (func() {
-				for k, _ := range tc.envVars {
-					os.Unsetenv(k)
-				}
-			})()
 
 			var val interface{}
 			var err error

--- a/internal/env/types_internal_test.go
+++ b/internal/env/types_internal_test.go
@@ -1,7 +1,6 @@
 package env
 
 import (
-	"os"
 	"testing"
 )
 
@@ -17,15 +16,8 @@ func TestReplaceEnvVar(t *testing.T) {
 		return func(t *testing.T) {
 			// setup our env vars
 			for k, v := range tc.envVars {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
-
-			// clean up env vars
-			defer (func() {
-				for k, _ := range tc.envVars {
-					os.Unsetenv(k)
-				}
-			})()
 
 			out, err := replaceEnvVar(tc.in)
 			if tc.expectedErr != nil {

--- a/internal/ttools/getenv_test.go
+++ b/internal/ttools/getenv_test.go
@@ -1,7 +1,6 @@
 package ttools
 
 import (
-	"os"
 	"testing"
 )
 
@@ -10,14 +9,9 @@ const (
 	ENV_TEST_EMPTY_VARIABLE = ""
 )
 
-func setEnv() {
-	os.Setenv("ENV_TEST_VARIABLE", ENV_TEST_VARIABLE)
-	os.Setenv("ENV_TEST_EMPTY_VARIABLE", ENV_TEST_EMPTY_VARIABLE)
-}
-
-func unsetEnv() {
-	os.Unsetenv("ENV_TEST_VARIABLE")
-	os.Unsetenv("ENV_TEST_EMPTY_VARIABLE")
+func setEnv(t *testing.T) {
+	t.Setenv("ENV_TEST_VARIABLE", ENV_TEST_VARIABLE)
+	t.Setenv("ENV_TEST_EMPTY_VARIABLE", ENV_TEST_EMPTY_VARIABLE)
 }
 
 func TestGetEnvDefault(t *testing.T) {
@@ -27,8 +21,7 @@ func TestGetEnvDefault(t *testing.T) {
 		expected string
 	}
 
-	setEnv()
-	defer unsetEnv()
+	setEnv(t)
 
 	fn := func(tc tcase) func(*testing.T) {
 		return func(t *testing.T) {


### PR DESCRIPTION
This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```