### PR TITLE
fix: cache/gcs dropped errs

### DIFF
--- a/cache/gcs/gcs.go
+++ b/cache/gcs/gcs.go
@@ -47,13 +47,21 @@ func New(config dict.Dicter) (cache.Interface, error) {
 	}
 
 	gcsCache.Basepath, err = config.String(ConfigKeyBasepath, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	defaultMaxZoom := uint(tegola.MaxZ)
+
 	gcsCache.MaxZoom, err = config.Uint(ConfigKeyMaxZoom, &defaultMaxZoom)
+	if err != nil {
+		return nil, err
+	}
 
 	gcsCache.Ctx = context.Background()
 	client, err := storage.NewClient(gcsCache.Ctx)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	gcsCache.Client = client
 	gcsCache.Bucket = client.Bucket(gcsCache.BucketName)


### PR DESCRIPTION
This picks up two dropped `err` variables in `cache/gcs`.