### PR TITLE
Fix ui version checking during build

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -11,7 +11,7 @@ var (
 	Version              = "version not set"
 	GitRevision          = "not set"
 	GitBranch            = "not set"
-	uiVersionDefaultText = "viewer not build"
+	uiVersionDefaultText = "viewer not built"
 	Tags                 []string
 	Commands             = []string{"tegola"}
 )

--- a/internal/build/viewer.go
+++ b/internal/build/viewer.go
@@ -5,22 +5,13 @@ package build
 
 import (
 	"github.com/go-spatial/tegola/ui"
-	"io/fs"
-	"strings"
 )
 
 func ViewerVersion() string {
-	// get the js dir to get the app.${version}.js file
-	files, err := fs.ReadDir(ui.GetDistFS(), "js")
-	if err != nil {
+	version := ui.Version()
+	if version == "" {
 		return uiVersionDefaultText
 	}
-	for _, entry := range files {
-		name := entry.Name()
-		if strings.HasPrefix(name, "app.") && strings.HasSuffix(name, ".js") {
-			// expect it to be app.{version}.js
-			return name[4 : len(name)-3]
-		}
-	}
-	return uiVersionDefaultText
+
+	return version
 }

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+	"strings"
 
 	"github.com/go-spatial/tegola/internal/log"
 )
@@ -12,15 +13,39 @@ import (
 //go:embed dist/*
 var dist embed.FS
 
+const (
+	distDir       = "dist"
+	assetsDir     = "assets"
+	indexJSPrefix = "index-"
+)
+
 func GetDistFileSystem() http.FileSystem {
 	distFS := GetDistFS()
 	return http.FS(distFS)
 }
 
 func GetDistFS() fs.FS {
-	distFS, err := fs.Sub(dist, "dist")
+	distFS, err := fs.Sub(dist, distDir)
 	if err != nil {
 		log.Fatal(err)
 	}
 	return distFS
+}
+
+func Version() string {
+	// read the assets/ directory so we can attempt to find the built .js file
+	files, err := fs.ReadDir(GetDistFS(), assetsDir)
+	if err != nil {
+		return ""
+	}
+
+	for _, entry := range files {
+		name := entry.Name()
+		if strings.HasPrefix(name, indexJSPrefix) && strings.HasSuffix(name, ".js") {
+			// expect it to be index-{version}.js
+			return name[len(indexJSPrefix) : len(name)-3]
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
The compiled UI code naming convention changed at some point and the previous way to parse the version from the file name no longer aligned with the new convention.

closes #942