### PR TITLE
provider/hana: fix dropped error

### DIFF
--- a/provider/hana/hana.go
+++ b/provider/hana/hana.go
@@ -349,6 +349,9 @@ func CreateConnection(config dict.Dicter) (*sql.DB, error) {
 	}
 
 	db, err := OpenDB(uri)
+	if err != nil {
+		return db, err
+	}
 	if err := db.Ping(); err != nil {
 		return nil, fmt.Errorf("Failed while establishing connection: %v", err)
 	}


### PR DESCRIPTION
This fixes a dropped `err` variable in the `provider/hana` package.