### PR TITLE
Bump Go version to 1.21.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@
 #  $ docker run -v /path/to/docker-config:/opt/tegola_config -p 8080 tegola serve
 
 # Intermediary container for building
-FROM golang:1.20.5-alpine3.18 AS build
+FROM golang:1.21.8-alpine3.18 AS build
 
 ARG BUILDPKG="github.com/go-spatial/tegola/internal/build"
 ARG VER="Version Not Set"

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The requested tile will be encoded with a layer that has the `name` value set to
 
 ## Building from source
 
-Tegola is written in [Go](https://golang.org/) and requires [Go 1.19](https://go.dev/dl/) or higher to compile from the source. 
+Tegola is written in [Go](https://golang.org/) and requires [Go 1.21](https://go.dev/dl/) or higher to compile from the source. 
 (We support the two newest versions of Go.) 
 To build tegola from the source, make sure you have Go installed and have cloned the repository. 
 Navigate to the repository then run the following command:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-spatial/tegola
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/storage v1.28.1


### PR DESCRIPTION
@gdey this bumps Go up to 1.21.8 to address some of the stdlib vulns. govulncheck is still failing on a few other dependencies that I will update after this one lands. 