### PR TITLE
cache: allow to set a local proxy endpoint for s3

### DIFF
--- a/cache/s3/README.md
+++ b/cache/s3/README.md
@@ -22,7 +22,7 @@ The s3cache config supports the following properties:
 - `cache_control` (string): [Optional] the HTTP cache control header to set on the file when putting the file. defaults to ''.
 - `content_type` (string): [Optional] the http MIME-type set on the file when putting the file. defaults to 'application/vnd.mapbox-vector-tile'.
 - `force_path_style` (bool): [Optional] use path-style addressing instead of virtual hosted-style addressing (i.e. http://s3.amazonaws.com/BUCKET/KEY instead of http://BUCKET.s3.amazonaws.com/KEY)
-
+- `req_signing_host` (string): [Optional] force AWS request signing to use a different Host value, useful when `endpoint` is set to a a local proxy/sidecar.
 
 ## Credential chain
 If the `aws_access_key_id` and `aws_secret_access_key` are not set, then the [credential provider chain](http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) will be used. The provider chain supports multiple methods for passing credentials, one of which is setting environment variables. For example:
@@ -43,3 +43,12 @@ $ export AWS_REGION=TEST_BUCKET_REGION
 $ export AWS_ACCESS_KEY_ID=YOUR_AKID
 $ export AWS_SECRET_ACCESS_KEY=YOUR_SECRET_KEY
 ```
+
+## Use a local proxy or sidecar (in k8s)
+If `endpoint` is set to a local reverse proxy (like `http://localhost:1234`), then AWS request signing will not work: the real S3 endpoint will return a HTTP 403 error saying:
+
+```
+SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your key and signing method.
+```
+
+To make it work, the `req_signing_host` is a special parameter that forces Tegola to use a different HTTP Host header value when the AWS sdk signs the request to be sent to the real S3 endpoint. It needs to be set to the Host header (so no http:// prefixes etc..) of the real S3 endpoint (behind the reverse proxy for example).


### PR DESCRIPTION
Hi folks!

At Wikimedia we use Tegola on Kubernetes and recently we noticed a performance regression when the internal S3 endpoint changed its TLS certificate (more info https://phabricator.wikimedia.org/T344324). We currently use version 0.19.x, we haven't tested the more recent ones, but we'd like to use a local sidecar/proxy to improve HTTP connection pooling and similar settings.

We are currently connecting from the pod directly to the internal S3 endpoint, and we may explore other alternatives if you don't like the one proposed in this patch. The only one that comes to mind is adding explicit settings to tune HTTP connection pooling and similar in tegola's AWS sdk config for S3.

Technical details:
If Tegola is configured to use a s3 cache endpoint like http://localhost:1234, the AWS request signing step is not done correctly and the real S3 endpoint will return a HTTP 403 stating that the request signing header value doesn't match what it expects.
This is a typical use case in k8s, where the HTTP connection go through a local sidecar/proxy. 
In our case, we have an internal S3 endpoint (implemented via Openstack Swift) and we noticed an increase in CPU usage in the pod running tegola when the TLS cert of the S3 endpoint changed (probably due to high requirements for the Cipher suite). We would like to implement in the local proxy connection pooling and other similar performance improvements, without necessarily changing any of the Tegola's code or settings. We'd also get HTTP metrics for free from the sidecar, without the need of instrumenting Tegola.

Let me know your thoughts! Thanks in advance :) 