### PR TITLE
Layer names that are substrings cause atlas to serve all layers that match

### DIFF
--- a/atlas/map.go
+++ b/atlas/map.go
@@ -167,7 +167,7 @@ func (m Map) FilterLayersByName(names ...string) Map {
 	nameStr := strings.Join(names, ",")
 	for i := range m.Layers {
 		// if we have a name set, use it for the lookup
-		if m.Layers[i].Name != "" && strings.Contains(nameStr, m.Layers[i].Name) {
+		if m.Layers[i].Name != "" && nameStr == m.Layers[i].Name {
 			layers = append(layers, m.Layers[i])
 			continue
 		} else if m.Layers[i].ProviderLayerName != "" && strings.Contains(nameStr, m.Layers[i].ProviderLayerName) { // default to using the ProviderLayerName for the lookup

--- a/atlas/map_test.go
+++ b/atlas/map_test.go
@@ -176,6 +176,26 @@ func TestMapFilterLayersByName(t *testing.T) {
 				},
 			},
 		},
+		{
+			grid: atlas.Map{
+				Layers: []atlas.Layer{
+					{
+						Name: "layer1",
+					},
+					{
+						Name: "layer1roads",
+					},
+				},
+			},
+			name: "layer1roads",
+			expected: atlas.Map{
+				Layers: []atlas.Layer{
+					{
+						Name: "layer1roads",
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testcases {


### PR DESCRIPTION
refers to #869 

use direct comparison instead of strings.Contains to filter layernames

happy to discuss if we need to support both approaches.

