### PR TITLE
ci: build docker only when secrets are present

### DIFF
--- a/.github/workflows/on_release_publish.yml
+++ b/.github/workflows/on_release_publish.yml
@@ -1,12 +1,13 @@
 name: On release publish
 on: 
-  push:
   pull_request:
+  push:
+    branches:
+      - master
   release:
     types: [published]
 
 jobs:
-
   gen_version:
     name: Generate software version
     runs-on: ubuntu-22.04
@@ -223,6 +224,8 @@ jobs:
     needs: [gen_version,build_ui]
     runs-on: ubuntu-22.04
     env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       DOCKERHUB_ORG: gospatial
       DOCKERHUB_REPO: tegola
       BUILD_ARGS: |
@@ -243,6 +246,7 @@ jobs:
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3
+      if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -259,6 +263,7 @@ jobs:
     # we are not rebuilding linux/amd64
     - name: Build docker image for testing
       uses: docker/build-push-action@v5
+      if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
       with:
         context: .
         load: true
@@ -267,6 +272,7 @@ jobs:
         tags: ${{ env.DOCKERHUB_ORG }}/${{ env.DOCKERHUB_REPO }}:${{ env.VERSION }}
 
     - name: Test image build
+      if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
       run: |
         docker run --rm ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${VERSION} version
 


### PR DESCRIPTION
as discussed in #995 docker build should only run if `secrets.DOCKERHUB_USERNAME` and `secrets.DOCKERHUB_TOKEN` are present.