### PR TITLE
fix: fix slice init length

### DIFF
--- a/observability/observability.go
+++ b/observability/observability.go
@@ -142,7 +142,7 @@ func Register(observerType string, init InitFunc, cleanup CleanUpFunc) error {
 
 // Registered returns the set of Registered observers
 func Registered() []string {
-	obs := make([]string, len(observers))
+	obs := make([]string, 0, len(observers))
 	for k := range observers {
 		obs = append(obs, k)
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of `len(observers)` rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW