### PR TITLE
ci: dont attempt to publish edge container if credentials are not present

### DIFF
--- a/.github/workflows/on_release_publish.yml
+++ b/.github/workflows/on_release_publish.yml
@@ -277,7 +277,7 @@ jobs:
         docker run --rm ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${VERSION} version
 
     - name: Publish Docker edge container
-      if: github.ref == env.DEFAULT_BRANCH_REF
+      if: github.ref == env.DEFAULT_BRANCH_REF && (env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '')
       uses: docker/build-push-action@v5
       with:
         context: .


### PR DESCRIPTION
# description

- ci will always fail on branches because docker credentials live upstream

I think the CI is due for an overhaul, as this is just bandage for a bigger misconfiguration. I remember we had to have that default branch logic, because tegola had named default branches that'd change version to version. This is no longer the case, so we could clean that up altogether. 

Might be worth looking into [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) and automatic release tagging using [svu](https://github.com/caarlos0/svu) paired with [goreleaser](https://github.com/goreleaser/goreleaser).