### PR TITLE
Extend warning about large tiles with information about map and layer requested

### DIFF
--- a/server/handle_map_layer_zxy.go
+++ b/server/handle_map_layer_zxy.go
@@ -226,7 +226,7 @@ func (req HandleMapLayerZXY) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// check for tile size warnings
 	if len(pbyte) > MaxTileSize {
-		log.Infof("tile z:%v, x:%v, y:%v is rather large - %vKb", req.z, req.x, req.y, len(pbyte)/1024)
+		log.Infof("tile map:%s layer:%s z:%v, x:%v, y:%v is rather large - %vKb", req.map_name, req.layer_name, req.z, req.x, req.y, len(pbyte)/1024)
 	}
 }
 

--- a/server/handle_map_layer_zxy.go
+++ b/server/handle_map_layer_zxy.go
@@ -226,7 +226,7 @@ func (req HandleMapLayerZXY) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// check for tile size warnings
 	if len(pbyte) > MaxTileSize {
-		log.Infof("tile map:%s layer:%s z:%v, x:%v, y:%v is rather large - %vKb", req.map_name, req.layer_name, req.z, req.x, req.y, len(pbyte)/1024)
+		log.Infof("tile map:%s layer:%s z:%v, x:%v, y:%v is rather large - %vKb", req.mapName, req.layerName, req.z, req.x, req.y, len(pbyte)/1024)
 	}
 }
 


### PR DESCRIPTION
I have more than 10 maps in my tegola configuration and it's impossible to understand which one is large from logs.

```
tiles-1  | 2025-04-17 19:26:12 [INFO] config.go:405: loading local config (/configs/tegola.toml)
tiles-1  | 2025-04-17 19:26:12 [WARN] postgis.go:350: Connecting to PostGIS with connection parameters is deprecated. Use 'uri' instead.
tiles-1  | 2025-04-17 19:26:12 [INFO] providers.go:82: registering provider(type): kadastr (mvt_postgis)
tiles-1  | 2025-04-17 19:26:12 [INFO] server.go:102: starting tegola server (version not set) on port :8686
tiles-1  | 2025-04-17 19:26:20 [INFO] handle_map_layer_zxy.go:206: tile z:11, x:1223, y:708 is rather large - 995Kb
tiles-1  | 2025-04-17 19:26:20 [INFO] handle_map_layer_zxy.go:206: tile z:11, x:1222, y:707 is rather large - 834Kb
tiles-1  | 2025-04-17 19:26:21 [INFO] handle_map_layer_zxy.go:206: tile z:11, x:1223, y:707 is rather large - 1303Kb
tiles-1  | 2025-04-17 19:26:21 [INFO] handle_map_layer_zxy.go:206: tile z:11, x:1194, y:691 is rather large - 491Kb
tiles-1  | 2025-04-17 19:26:22 [INFO] handle_map_layer_zxy.go:206: tile z:11, x:1195, y:692 is rather large - 616Kb
tiles-1  | 2025-04-17 19:26:23 [INFO] handle_map_layer_zxy.go:206: tile z:11, x:1195, y:691 is rather large - 871Kb
```

I suggest adding information about map and layer requested:

```
Attaching to tiles-1
tiles-1  | 2025-04-17 20:01:43 [INFO] config.go:406: loading local config (/configs/tegola.toml)
tiles-1  | 2025-04-17 20:01:43 [INFO] providers.go:82: registering provider(type): kadastr (mvt_postgis)
tiles-1  | 2025-04-17 20:01:43 [INFO] server.go:108: starting tegola server (version not set) on port :8686
tiles-1  | 2025-04-17 20:01:53 [INFO] handle_map_layer_zxy.go:229: tile map:kadastr layer: z:11, x:1195, y:691 is rather large - 873Kb
tiles-1  | 2025-04-17 20:02:17 [INFO] handle_map_layer_zxy.go:229: tile map:kadastr layer: z:11, x:1207, y:707 is rather large - 1127Kb
```

It costs nothing, but it's much easier to understand what is going on.

