### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/provider/hana/hana_test.go
+++ b/provider/hana/hana_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"testing"
@@ -40,14 +41,10 @@ func (cfg TCConfig) Config() dict.Dict {
 		mConfig = cfg.BaseConfig
 	}
 	config = make(map[string]interface{}, len(mConfig))
-	for k, v := range mConfig {
-		config[k] = v
-	}
+	maps.Copy(config, mConfig)
 
 	// set the config overrides
-	for k, v := range cfg.ConfigOverride {
-		config[k] = v
-	}
+	maps.Copy(config, cfg.ConfigOverride)
 
 	if len(cfg.LayerConfig) > 0 {
 		layerConfig, _ := config[hana.ConfigKeyLayers].([]map[string]interface{})

--- a/provider/postgis/postgis_internal_test.go
+++ b/provider/postgis/postgis_internal_test.go
@@ -3,6 +3,7 @@ package postgis
 import (
 	"bytes"
 	"context"
+	"maps"
 	"reflect"
 	"strings"
 	"testing"
@@ -57,14 +58,10 @@ func (cfg TCConfig) Config(mConfig map[string]any) dict.Dict {
 		mConfig = cfg.BaseConfig
 	}
 	config = make(map[string]any, len(mConfig))
-	for k, v := range mConfig {
-		config[k] = v
-	}
+	maps.Copy(config, mConfig)
 
 	// set the config overrides
-	for k, v := range cfg.ConfigOverride {
-		config[k] = v
-	}
+	maps.Copy(config, cfg.ConfigOverride)
 
 	if len(cfg.LayerConfig) > 0 {
 		layerConfig, _ := config[ConfigKeyLayers].([]map[string]any)


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.