### PR TITLE
feat: add lazy ttl on file cache

### DIFF
--- a/cache/file/README.md
+++ b/cache/file/README.md
@@ -6,6 +6,7 @@ filecache uses a file system for caching tiles. To use it, add the following min
 [cache]
 type="file"
 basepath="/tmp/tegola-cache"
+ttl=1
 ```
 
 ## Properties
@@ -13,3 +14,4 @@ The filecache config supports the following properties:
 
 - `basepath` (string): [Required] a location on the file system to write the cached tiles to.
 - `max_zoom` (int): [Optional] the max zoom the cache should cache to. After this zoom, Set() calls will return before doing work.
+- `ttl` (int): [Optional] time to live in seconds for cached tiles. Defaults to 0 (never expires). TTL is evaluated lazily on Get() operations - expired tiles are deleted when accessed but may remain on disk if never requested.


### PR DESCRIPTION
Closes #1068 

This introduces a lazy tile cache invalidation for the file tile cache. On request we look up the tile on the FS. If `now + ttl > mtime` we delete the old file and report a miss to the caller.
This approach is simple. The caveat is that unrequested tiles remain on the FS until requested.

cc @ARolek @Edefritz