### PR TITLE
refactor: postgis connection with environment taking precedence over uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ name = "zoning"                           # used in the URL to reference this ma
 
 ## Environment Variables
 
-#### Config TOML
+### Config TOML
 
 Environment variables can be injected into the configuration file. One caveat is that the injection has to be within a string, though the value it represents does not have to be a string.
 

--- a/mvtprovider/postgis/README.md
+++ b/mvtprovider/postgis/README.md
@@ -8,8 +8,25 @@ The connection between tegola and PostGIS is configured in a `tegola.toml` file.
 [[providers]]
 name = "test_postgis"       # provider name is referenced from map layers (required)
 type = "mvt_postgis"        # the type of data provider must be "mvt_postgis" for this data provider (required)
-uri = "postgres://postgres:postgres@localhost:5432/tegola"          # PostGIS database uri (required)
+uri = "postgres://postgres:postgres@localhost:5432/tegola"          # PostGIS database uri (optional)
 ```
+### env mode vs uri mode
+
+Connection related environment variables take full precedence over `uri` when any trigger (PGHOST,PGPASSWORD,PGUSER,PGDATABASE,PGPORT) is present 
+in the environment. With this we follow [libpq environment variables](https://www.postgresql.org/docs/current/libpq-envars.html) and allow users to configure they're connection entirely through the environment.
+
+```
+if env trigger variables present:
+    mode = env
+    ignore uri, uses env vars to establish connection
+    can be enriched with config values
+else:
+    mode = uri, either uri controls it all, or we can enrich with config values
+```
+
+> [!WARNING]
+> Configuring multiple postgis providers in the same application requires the 
+> use of a a connection string.
 
 ## Connection Properties
 

--- a/provider/postgis/README.md
+++ b/provider/postgis/README.md
@@ -32,13 +32,28 @@ default_transaction_read_only = "off"
 
 ## Connection Properties
 
-Establishing a connection via connection string (`uri`) will become the default
-connection method as of v0.16.0. Connecting via host/port/database is deprecated.
-
--   `uri` (string): [Required] PostGIS connection string
+-   `uri` (string): [Optional] PostGIS connection string
 -   `name` (string): [Required] provider name is referenced from map layers
--   `type` (string): [Required] the type of data provider. must be "postgis" to use this data provider
+-   `type` (string): [Required] the type of data provider. enum: postgis, mvt_postgis. 
 -   `srid` (int): [Optional] The default SRID for the provider. Defaults to WebMercator (3857) but also supports WGS84 (4326)
+
+### env mode vs uri mode
+
+Connection related environment variables take full precedence over `uri` when any trigger (PGHOST,PGPASSWORD,PGUSER,PGDATABASE,PGPORT) is present 
+in the environment. With this we follow [libpq environment variables](https://www.postgresql.org/docs/current/libpq-envars.html) and allow users to configure they're connection entirely through the environment.
+
+```
+if env trigger variables present:
+    mode = env
+    ignore uri, uses env vars to establish connection
+    can be enriched with config values
+else:
+    mode = uri, either uri controls it all, or we can enrich with config values
+```
+
+> [!WARNING]
+> Configuring multiple postgis providers in the same application requires the 
+> use of a a connection string.
 
 ### Connection string properties
 

--- a/provider/postgis/builder.go
+++ b/provider/postgis/builder.go
@@ -1,0 +1,228 @@
+package postgis
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	pgxuuid "github.com/jackc/pgx-gofrs-uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/tracelog"
+)
+
+// builder defines the interface responsible for constructing a pgxpool
+// configuration from a resolved connection plan. It is wiring up
+// the configuration, it is not responsible for validation.
+type builder interface {
+	Build(ctx context.Context, plan connPlan) (*pgxpool.Config, error)
+}
+
+type parseConfigFn func(uri string) (*pgxpool.Config, error)
+
+// defaultBuilder is the default pgxpool config builder for the postgis provider.
+// It construct the pgxpool.Config from a connPlan, appplyes tracer configuration,
+// connection hooks, runtime parameters and TLS settings.
+type defaultBuilder struct {
+	parse parseConfigFn
+}
+
+// newDefaultBuilder creates a new defaultBuilder..
+func newDefaultBuilder() *defaultBuilder {
+	return &defaultBuilder{parse: pgxpool.ParseConfig}
+}
+
+// Build builds the connection pgxpool config from the connection plan.
+func (b *defaultBuilder) Build(ctx context.Context, plan connPlan) (*pgxpool.Config, error) {
+	uri := ""
+	if plan.Mode == connModeURI {
+		uri = plan.URIString
+	}
+
+	cfg, err := b.parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	b.applyTracer(cfg)
+	b.applyAfterConnectHook(cfg)
+	b.applyRunTimeParams(cfg, plan)
+
+	if tErr := b.applyTLS(cfg, plan); tErr != nil {
+		return nil, tErr
+	}
+
+	return cfg, nil
+}
+
+// applyTracer injects our logger into the pgx logger.
+func (b *defaultBuilder) applyTracer(cfg *pgxpool.Config) {
+	logAdapter := NewLoggerAdapter()
+	tracer := &tracelog.TraceLog{
+		Logger:   logAdapter,
+		LogLevel: tracelog.LogLevelWarn,
+	}
+	cfg.ConnConfig.Tracer = tracer
+}
+
+// applyAfterConnectHook adds the hstore and uuid type to the pool configs
+// after connect hooks.
+func (b *defaultBuilder) applyAfterConnectHook(cfg *pgxpool.Config) {
+	type hstoreOID struct {
+		OID     uint32
+		hasInit bool
+	}
+	var hstore hstoreOID
+	cfg.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		// The AfterConnect call runs everytime a new connection is acquired,
+		// including everytime the connection pool expands. The hstore OID
+		// is not constant, so we lookup the OID once per provider and store it.
+		// Extensions have to be registered for every new connection.
+		if !hstore.hasInit {
+			row := conn.QueryRow(ctx, "SELECT oid FROM pg_type WHERE typname = 'hstore';")
+			if err := row.Scan(&hstore.OID); err != nil {
+				switch {
+				case errors.Is(err, pgx.ErrNoRows):
+					// do nothing, because query can be empty if hstore is not installed
+					break
+				default:
+					return fmt.Errorf("error fetching hstore oid: %w", err)
+				}
+			}
+
+			hstore.hasInit = true
+		}
+
+		// dont register hstore data type if hstore extension is not installed
+		if hstore.OID != 0 {
+			conn.TypeMap().RegisterType(&pgtype.Type{
+				Name:  "hstore",
+				OID:   hstore.OID,
+				Codec: pgtype.HstoreCodec{},
+			})
+		}
+
+		// register UUID type, see https://github.com/jackc/pgx/wiki/UUID-Support
+		pgxuuid.Register(conn.TypeMap())
+
+		return nil
+	}
+}
+
+// applyRunTimeParams adds adds runtime parameters to the pool config.
+func (b *defaultBuilder) applyRunTimeParams(cfg *pgxpool.Config, plan connPlan) {
+	cfg.ConnConfig.RuntimeParams = plan.RuntimeParams
+}
+
+// applyTLS applys the connection plan TLS configuration to the pool config.
+func (b *defaultBuilder) applyTLS(cfg *pgxpool.Config, plan connPlan) error {
+	switch plan.SSLMode {
+	case SSLModeDisable, SSLModeEmpty:
+		cfg.ConnConfig.TLSConfig = nil
+		return nil
+
+	case SSLModeAllow, SSLModePrefer, SSLModeRequire:
+		cfg.ConnConfig.TLSConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+
+	case SSLModeVerifyFull:
+		// Standard Go verification: chain + hostname.
+		// ServerName is required for hostname verification.
+		cfg.ConnConfig.TLSConfig = &tls.Config{
+			ServerName: cfg.ConnConfig.Host,
+		}
+
+	case SSLModeVerifyCA:
+		// Go doesn't support "verify chain but skip hostname" directly.
+		// We must set InsecureSkipVerify=true and perform chain verification ourselves.
+		cfg.ConnConfig.TLSConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+
+		installVerifyCA(cfg.ConnConfig.TLSConfig)
+
+	default:
+		return ErrInvalidSSLMode(plan.SSLMode)
+	}
+
+	// Load root certs if provided (otherwise system roots apply).
+	if plan.SSLRootCert != "" {
+		pool := x509.NewCertPool()
+
+		pem, err := os.ReadFile(plan.SSLRootCert)
+		if err != nil {
+			return fmt.Errorf("unable to read CA file (%q): %w", plan.SSLRootCert, err)
+		}
+		if !pool.AppendCertsFromPEM(pem) {
+			return fmt.Errorf("unable to add CA to cert pool")
+		}
+
+		cfg.ConnConfig.TLSConfig.RootCAs = pool
+	}
+
+	// Optional client cert auth.
+	if (plan.SSLCert == "") != (plan.SSLKey == "") {
+		return fmt.Errorf("both 'sslcert' and 'sslkey' are required")
+	}
+	if plan.SSLCert != "" {
+		cert, err := tls.LoadX509KeyPair(plan.SSLCert, plan.SSLKey)
+		if err != nil {
+			return fmt.Errorf("unable to read cert: %w", err)
+		}
+		cfg.ConnConfig.TLSConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return nil
+}
+
+// installVerifyCA configures VerifyPeerCertificate to validate the server cert chain
+// against RootCAs (or system roots if RootCAs is nil), without hostname verification.
+func installVerifyCA(tcfg *tls.Config) {
+	tcfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		if len(rawCerts) == 0 {
+			return fmt.Errorf("no server certificates presented")
+		}
+
+		leaf, err := x509.ParseCertificate(rawCerts[0])
+		if err != nil {
+			return fmt.Errorf("parse leaf certificate: %w", err)
+		}
+
+		roots := tcfg.RootCAs
+		if roots == nil {
+			sys, err := x509.SystemCertPool()
+			if err != nil {
+				return fmt.Errorf("load system cert pool: %w", err)
+			}
+			roots = sys
+		}
+
+		intermediates := x509.NewCertPool()
+		for i := 1; i < len(rawCerts); i++ {
+			c, err := x509.ParseCertificate(rawCerts[i])
+			if err != nil {
+				return fmt.Errorf("parse intermediate certificate: %w", err)
+			}
+			intermediates.AddCert(c)
+		}
+
+		opts := x509.VerifyOptions{
+			Roots:         roots,
+			Intermediates: intermediates,
+			CurrentTime:   time.Now(),
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			// DNSName intentionally empty -> no hostname verification
+		}
+
+		if _, err := leaf.Verify(opts); err != nil {
+			return fmt.Errorf("verify-ca failed: %w", err)
+		}
+		return nil
+	}
+}

--- a/provider/postgis/builder_test.go
+++ b/provider/postgis/builder_test.go
@@ -1,0 +1,198 @@
+package postgis
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestBuilderParseInput(t *testing.T) {
+	type tcase struct {
+		plan        connPlan
+		expectedURI string
+	}
+
+	tcases := map[string]tcase{
+		"connModeEnv": {
+			plan: connPlan{
+				Mode:    connModeEnv,
+				SSLMode: "disable",
+			},
+		},
+		"connModeConfig": {
+			plan: connPlan{
+				Mode:      connModeURI,
+				URIString: "postgres://user:password@localhost:5432/db?sslmode=disable",
+			},
+		},
+	}
+
+	fn := func(t *testing.T, tc tcase) {
+		t.Helper()
+
+		ctx := t.Context()
+		var got string
+		b := &defaultBuilder{
+			parse: func(s string) (*pgxpool.Config, error) {
+				got = s
+				return pgxpool.ParseConfig("")
+			},
+		}
+		_, err := b.Build(ctx, tc.plan)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.plan.URIString {
+			t.Fatalf("expected parse input uri to be %q, got %q", tc.expectedURI, got)
+		}
+	}
+
+	for name, tc := range tcases {
+		t.Run(name, func(t *testing.T) {
+			fn(t, tc)
+		})
+	}
+}
+
+func TestBuilderApplyRuntimeParams(t *testing.T) {
+	type tcase struct {
+		plan connPlan
+	}
+
+	tcases := map[string]tcase{
+		"connModeEnv": {
+			plan: connPlan{
+				Mode:    connModeEnv,
+				SSLMode: "disable",
+
+				RuntimeParams: runtimeParams{
+					"application_name": "testing",
+				},
+			},
+		},
+		"connModeConfig": {
+			plan: connPlan{
+				Mode:      connModeURI,
+				URIString: "postgres://user:password@localhost:5432/db?sslmode=disable",
+				RuntimeParams: runtimeParams{
+					"application_name":              "testing",
+					"default_transaction_read_only": "true",
+				},
+			},
+		},
+	}
+
+	fn := func(t *testing.T, tc tcase) {
+		ctx := t.Context()
+		b := newDefaultBuilder()
+		cfg, err := b.Build(ctx, tc.plan)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for k, v := range tc.plan.RuntimeParams {
+			got := cfg.ConnConfig.RuntimeParams[k]
+			if got != v {
+				t.Fatalf("expected %q but got %q", v, got)
+			}
+		}
+	}
+
+	for name, tc := range tcases {
+		t.Run(name, func(t *testing.T) {
+			fn(t, tc)
+		})
+	}
+}
+
+func TestBuilderApplyTLS(t *testing.T) {
+	type tcase struct {
+		sslmode          SSLMode
+		expectNil        bool
+		expectVerifyCA   bool
+		expectServerName bool
+	}
+
+	tcases := map[SSLMode]tcase{
+		SSLModeDisable: {
+			sslmode:          SSLModeDisable,
+			expectNil:        true,
+			expectVerifyCA:   false,
+			expectServerName: false,
+		},
+		SSLModeEmpty: {
+			sslmode:          SSLModeEmpty,
+			expectNil:        true,
+			expectVerifyCA:   false,
+			expectServerName: false,
+		},
+		SSLModeRequire: {
+			sslmode:          SSLModeRequire,
+			expectNil:        false,
+			expectVerifyCA:   false,
+			expectServerName: false,
+		},
+		SSLModeVerifyFull: {
+			sslmode:          SSLModeVerifyFull,
+			expectNil:        false,
+			expectVerifyCA:   false,
+			expectServerName: true,
+		},
+		SSLModeVerifyCA: {
+			sslmode:          SSLModeVerifyCA,
+			expectNil:        false,
+			expectVerifyCA:   true,
+			expectServerName: false,
+		},
+	}
+
+	fn := func(t *testing.T, tc tcase) {
+		ctx := t.Context()
+		b := newDefaultBuilder()
+		cfg, err := b.Build(ctx, connPlan{Mode: connModeEnv, SSLMode: tc.sslmode})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if tc.expectNil {
+			if cfg.ConnConfig.TLSConfig != nil {
+				t.Fatal("expected TLSConfig to be nil")
+			}
+			return
+		}
+
+		fmt.Println(cfg.ConnConfig.TLSConfig)
+
+		if cfg.ConnConfig.TLSConfig == nil {
+			t.Fatal("expected TLSConfig to be not-nil")
+		}
+
+		if tc.expectVerifyCA && cfg.ConnConfig.TLSConfig.VerifyPeerCertificate == nil {
+			t.Fatalf("expected VerifyPeerCertificate set when SSLMode=%q", string(tc.sslmode))
+		}
+
+		if tc.expectServerName && cfg.ConnConfig.TLSConfig.ServerName == "" {
+			t.Fatal("expected ServerName to be set")
+		}
+	}
+
+	for sslmode, tc := range tcases {
+		t.Run(string(sslmode), func(t *testing.T) {
+			fn(t, tc)
+		})
+	}
+}
+
+func TestBuilderApplyAfterConnectHook(t *testing.T) {
+	ctx := t.Context()
+	b := newDefaultBuilder()
+	cfg, err := b.Build(ctx, connPlan{Mode: connModeEnv, SSLMode: SSLModeDisable})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.AfterConnect == nil {
+		t.Fatal("expected AfterConnect hooks to be not-nil")
+	}
+}

--- a/provider/postgis/collector.go
+++ b/provider/postgis/collector.go
@@ -1,0 +1,86 @@
+package postgis
+
+import (
+	"strings"
+
+	"github.com/go-spatial/tegola/observability"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type connectionPoolCollector struct {
+	*pgxpool.Pool
+
+	// providerName the pool is created for
+	// required to make metrics unique
+	providerName string
+
+	maxConnectionDesc        *prometheus.Desc
+	currentConnectionsDesc   *prometheus.Desc
+	availableConnectionsDesc *prometheus.Desc
+}
+
+func (c connectionPoolCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+func (c connectionPoolCollector) Collect(ch chan<- prometheus.Metric) {
+	if c.Pool == nil {
+		return
+	}
+	stat := c.Stat()
+
+	ch <- prometheus.MustNewConstMetric(
+		c.maxConnectionDesc,
+		prometheus.GaugeValue,
+		float64(stat.MaxConns()),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.currentConnectionsDesc,
+		prometheus.GaugeValue,
+		float64(stat.AcquiredConns()),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.availableConnectionsDesc,
+		prometheus.GaugeValue,
+		float64(stat.MaxConns()-stat.AcquiredConns()),
+	)
+}
+
+func (c *connectionPoolCollector) Collectors(
+	prefix string,
+	_ func(configKey string) map[string]any,
+) ([]observability.Collector, error) {
+	if c == nil {
+		return nil, nil
+	}
+	if prefix != "" && !strings.HasSuffix(prefix, "_") {
+		prefix = prefix + "_"
+	}
+
+	// a constant label ensures that the metrics are unique
+	// this allows the registration of multiple providers in the same
+	// config.
+	c.maxConnectionDesc = prometheus.NewDesc(
+		prefix+"postgres_max_connections",
+		"Max number of postgres connections in the pool",
+		nil,
+		prometheus.Labels{"provider_name": c.providerName},
+	)
+
+	c.currentConnectionsDesc = prometheus.NewDesc(
+		prefix+"postgres_current_connections",
+		"Current number of postgres connections in the pool",
+		nil,
+		prometheus.Labels{"provider_name": c.providerName},
+	)
+
+	c.availableConnectionsDesc = prometheus.NewDesc(
+		prefix+"postgres_available_connections",
+		"Current number of available postgres connections in the pool",
+		nil,
+		prometheus.Labels{"provider_name": c.providerName},
+	)
+
+	return []observability.Collector{c}, nil
+}

--- a/provider/postgis/connector.go
+++ b/provider/postgis/connector.go
@@ -1,0 +1,112 @@
+package postgis
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-spatial/tegola/dict"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	// defaultPingTimeout defines the default timeout used when no deadline
+	// is present on the provided context during Connect.
+	defaultPingTimeout = time.Duration(2 * time.Second)
+)
+
+// connector defines the interface responsible for establishing a
+// validated PostgreSQL connection pool.
+type connector interface {
+	Connect(ctx context.Context) (*pgxpool.Pool, *pgxpool.Config, connMeta, error)
+}
+
+// newDefaultConnector constructs a defaultConnector using the provided
+// configuration.
+func newDefaultConnector(cfg dict.Dicter) *defaultConnector {
+	return &defaultConnector{
+		cfg:         cfg,
+		pingTimeout: defaultPingTimeout,
+
+		selector:  &envSelector{},
+		planner:   &defaultPlanner{},
+		builder:   newDefaultBuilder(),
+		validator: &defaultValidator{},
+	}
+}
+
+// defaultConnector is the default implementation of connector for
+// the PostGIS provider. It coordinates mode selection, planning,
+// configuration building, validation, and pool creation.
+type defaultConnector struct {
+	cfg         dict.Dicter
+	pingTimeout time.Duration
+
+	selector  selector
+	planner   planner
+	builder   builder
+	validator validator
+}
+
+// Connect establishes a PostGIS connection pool using the configured
+// selector, planner, builder, and validator.
+//
+// It resolves the connection mode, builds a pgxpool.Config from the
+// resulting plan, validates the resolved configuration, creates the
+// pool, and performs a connectivity check via Ping.
+//
+// If the provided context does not contain a deadline, a timeout based
+// on defaultPingTimeout (or the configured value) is applied to the
+// connect and ping operations.
+func (c *defaultConnector) Connect(ctx context.Context) (*pgxpool.Pool, *pgxpool.Config, connMeta, error) {
+	ctxConnect := ctx
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctxConnect, cancel = context.WithTimeout(ctx, c.pingTimeout)
+		defer cancel()
+	}
+
+	mode, triggers := c.selector.Select()
+	plan, err := c.planner.Plan(c.cfg, mode, triggers)
+	if err != nil {
+		return nil, nil, connMeta{}, err
+	}
+
+	pgxCfg, err := c.builder.Build(ctxConnect, plan)
+	if err != nil {
+		return nil, nil, connMeta{}, err
+	}
+
+	meta, err := c.validator.Validate(plan, pgxCfg)
+	if err != nil {
+		return nil, nil, meta, err
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctxConnect, pgxCfg)
+	if err != nil {
+		return nil, nil, meta, err
+	}
+
+	err = pool.Ping(ctxConnect)
+	if err != nil {
+		pool.Close()
+		return nil, nil, meta, wrapMeta(meta, err)
+	}
+
+	return pool, pgxCfg, meta, nil
+}
+
+func (c *defaultConnector) WithPingTimeout(d time.Duration) *defaultConnector {
+	c.pingTimeout = d
+	return c
+}
+
+// wrapMeta wraps a connection error with sanitized connection metadata.
+func wrapMeta(meta connMeta, err error) error {
+	return fmt.Errorf(
+		"connection failed (mode=%s, triggers=%s, host=%s, db=%s, user=%s, sslmode=%s): %w",
+		string(meta.Mode), buildBuffer(meta.EnvTriggerKeys),
+		meta.Host, meta.Database, meta.User,
+		string(meta.SSLMode), err,
+	)
+}

--- a/provider/postgis/connector_test.go
+++ b/provider/postgis/connector_test.go
@@ -1,0 +1,132 @@
+package postgis
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-spatial/tegola/dict"
+	"github.com/go-spatial/tegola/internal/ttools"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestConnector(t *testing.T) {
+	ttools.ShouldSkip(t, TESTENV)
+
+	type tcase struct {
+		config           dict.Dicter
+		env              map[string]string
+		expectedConnMode connMode
+		expectedSSLMode  SSLMode
+
+		expectErrFn func(t *testing.T, err error)
+	}
+
+	fn := func(t *testing.T, tc tcase) {
+		t.Helper()
+
+		ctx := t.Context()
+		if len(tc.env) != 0 {
+			for key, value := range tc.env {
+				t.Setenv(key, value)
+			}
+		}
+
+		c := newDefaultConnector(tc.config)
+
+		_, _, connMeta, err := c.Connect(ctx)
+		if err != nil && tc.expectErrFn == nil {
+			t.Fatalf("expected connection to be establish but got: %s", err)
+		}
+		if err != nil && tc.expectErrFn != nil {
+			tc.expectErrFn(t, err)
+			return
+		}
+
+		if connMeta.Mode != tc.expectedConnMode {
+			t.Fatalf("expected connMode: %s, but got: %s", tc.expectedConnMode, connMeta.Mode)
+		}
+
+		if tc.expectedSSLMode != "" {
+			if connMeta.SSLMode != tc.expectedSSLMode {
+				t.Fatalf("expected sslmode: %s, got: %s", tc.expectedSSLMode, connMeta.SSLMode)
+			}
+		}
+	}
+
+	tcases := map[string]tcase{
+		"connect with uri in connModeURI": {
+			config:           dict.Dict(DefaultConfig),
+			env:              map[string]string{},
+			expectedConnMode: connModeURI,
+		},
+		"connect via env vars in env mode": {
+			config: dict.Dict(map[string]any{}),
+			env: map[string]string{
+				"PGUSER":     "postgres",
+				"PGPASSWORD": "postgres",
+				"PGHOST":     "localhost",
+				"PGPORT":     "5432",
+				"PGDATABASE": "tegola",
+				"PGSSLMODE":  "disable",
+			},
+			expectedConnMode: connModeEnv,
+			expectedSSLMode:  SSLModeDisable,
+		},
+		"errs with pgconn.ConnectError": {
+			config: dict.Dict(map[string]any{}),
+			env: map[string]string{
+				"PGUSER":     "postgres",
+				"PGHOST":     "localhost",
+				"PGPORT":     "5432",
+				"PGDATABASE": "tegola",
+				"PGSSLMODE":  "disable",
+			},
+			expectedConnMode: connModeEnv,
+			expectedSSLMode:  SSLModeDisable,
+			expectErrFn: func(t *testing.T, err error) {
+				var ce *pgconn.ConnectError
+				if !errors.As(err, &ce) {
+					t.Errorf("expected pgconn.ConnectError, got %T (%v)", err, err)
+				}
+
+				// also check if meta is wrapped
+				validateIncludes := []string{
+					"connection failed",
+					"mode=", "triggers=", "host=",
+					"db=", "user=", "sslmode=",
+				}
+				for _, str := range validateIncludes {
+					if !strings.Contains(err.Error(), str) {
+						t.Errorf("expected contains '%s', got %T (%v)", str, err, err)
+					}
+				}
+			},
+		},
+		"errs with deadline exceeded": {
+			config: dict.Dict(map[string]any{}),
+			env: map[string]string{
+				"PGUSER":     "postgres",
+				"PGPASSWORD": "postgres",
+				"PGHOST":     "localhost",
+				"PGPORT":     "5432",
+				"PGDATABASE": "tegola",
+				"PGSSLMODE":  "prefer", // will force a failing connection
+			},
+			expectedConnMode: connModeEnv,
+			expectedSSLMode:  SSLModePrefer,
+			expectErrFn: func(t *testing.T, err error) {
+				if !errors.Is(err, context.DeadlineExceeded) {
+					t.Fatalf("expected deadline exceceded, got %T (%v)", err, err)
+				}
+			},
+		},
+	}
+
+	for name, tc := range tcases {
+		t.Run(name, func(t *testing.T) {
+			fn(t, tc)
+		})
+	}
+}

--- a/provider/postgis/error.go
+++ b/provider/postgis/error.go
@@ -5,9 +5,30 @@ import (
 	"fmt"
 )
 
-var (
-	ErrNilLayer = errors.New("layer is nil")
-)
+var ErrNilLayer = errors.New("layer is nil")
+
+// ErrEnvIncomplete is returned when environment mode is selected
+// but the resolved connection configuration is structurally incomplete.
+type ErrEnvIncomplete struct {
+	Triggers      []string
+	MissingFields []string
+	URIWasIgnored bool
+}
+
+// Error returns a descriptive message explaining that environment
+// mode was selected and the resolved connection configuration is
+// incomplete.
+func (e ErrEnvIncomplete) Error() string {
+	triggerStr := buildBuffer(e.Triggers)
+	mFieldsStr := buildBuffer(e.MissingFields)
+	errMsg := "environment mode selected due to " + triggerStr + " but resolved connection is incomplete: missing " + mFieldsStr + "."
+
+	if !e.URIWasIgnored {
+		return errMsg
+	}
+
+	return errMsg + " a URI was provided in config but ignored because env mode has precedence."
+}
 
 type ErrLayerNotFound struct {
 	LayerName string

--- a/provider/postgis/planner.go
+++ b/provider/postgis/planner.go
@@ -1,0 +1,334 @@
+package postgis
+
+import (
+	"errors"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/go-spatial/tegola/dict"
+)
+
+// SSLMode represents a PostgreSQL sslmode value.
+type SSLMode string
+
+const (
+	SSLModeEmpty      SSLMode = ""
+	SSLModeDisable    SSLMode = "disable"
+	SSLModeAllow      SSLMode = "allow"
+	SSLModePrefer     SSLMode = "prefer"
+	SSLModeRequire    SSLMode = "require"
+	SSLModeVerifyCA   SSLMode = "verify-ca"
+	SSLModeVerifyFull SSLMode = "verify-full"
+)
+
+type runtimeParams map[string]string
+
+// connPlan is the resolved connection inputs from
+// configuration and environment variables. It is the output of the
+// planner and the input to the connection builder.
+type connPlan struct {
+	Mode           connMode
+	EnvTriggerKeys []string
+
+	URIProvided bool
+	URIString   string
+
+	// resolved ssl inputs (paths + mode) used by ConfigTLS
+	SSLMode     SSLMode
+	SSLKey      string
+	SSLCert     string
+	SSLRootCert string
+
+	// resolved runtime params
+	RuntimeParams runtimeParams
+}
+
+// planner defines the interface to creating a connection plan from
+// a provider configuration and selected connMode.
+type planner interface {
+	Plan(cfg dict.Dicter, mode connMode, triggers []string) (connPlan, error)
+}
+
+// defaultPlanner is the default PostGIS planner
+type defaultPlanner struct{}
+
+// Plan creates parses the configuration, prioritizes environment variables over
+// configuration values and creates a connPlan based off of the connMode.
+func (dp defaultPlanner) Plan(cfg dict.Dicter, mode connMode, triggers []string) (connPlan, error) {
+	cp := connPlan{}
+
+	cp.Mode = mode
+	cp.EnvTriggerKeys = triggers
+
+	uriStr, _ := cfg.String(ConfigKeyURI, nil) //nolint:errcheck we validate for empty string instead
+	cp.URIProvided = uriStr != ""
+	cp.URIString = uriStr
+
+	cp.RuntimeParams = resolveRunTimeParams(cfg, defaultRuntimeParamRules())
+
+	// tls defaults from config
+	sslMode := DefaultSSLMode
+	sslMode, err := cfg.String(ConfigKeySSLMode, &sslMode)
+	if err != nil {
+		return connPlan{}, err
+	}
+
+	sslKey := DefaultSSLKey
+	sslKey, err = cfg.String(ConfigKeySSLKey, &sslKey)
+	if err != nil {
+		return connPlan{}, err
+	}
+
+	sslCert := DefaultSSLCert
+	sslCert, err = cfg.String(ConfigKeySSLCert, &sslCert)
+	if err != nil {
+		return connPlan{}, err
+	}
+
+	sslRoot := DefaultSSLCert
+	sslRoot, err = cfg.String(ConfigKeySSLRootCert, &sslRoot)
+	if err != nil {
+		return connPlan{}, err
+	}
+
+	// this is where we allow env to override tls inputs
+	// and return the finished plan
+	if mode == connModeEnv {
+		if v := strings.TrimSpace(os.Getenv("PGSSLMODE")); v != "" {
+			sslMode = v
+		}
+		if v := strings.TrimSpace(os.Getenv("PGSSLKEY")); v != "" {
+			sslKey = v
+		}
+		if v := strings.TrimSpace(os.Getenv("PGSSLCERT")); v != "" {
+			sslCert = v
+		}
+		if v := strings.TrimSpace(os.Getenv("PGSSLROOTCERT")); v != "" {
+			sslRoot = v
+		}
+
+		cp.SSLMode, cp.SSLKey, cp.SSLCert, cp.SSLRootCert = SSLMode(sslMode), sslKey, sslCert, sslRoot
+		return cp, nil
+	}
+
+	if !cp.URIProvided {
+		// on this path there's no way for us to create a configuration
+		// we do not have environment variables for the connection
+		// nor a URI from config.
+		return connPlan{}, errors.New("neither env vars nor uri provided")
+	}
+
+	uri, err := url.Parse(cp.URIString)
+	if err != nil {
+		return connPlan{}, &ErrInvalidURI{Err: err}
+	}
+
+	// we now only validate the scheme. an exhaustive check here
+	// is overkill and best handled when establishing and testing the connection.
+	// see viable uri schema of libpq:
+	// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS
+	if uri.Scheme != "postgres" && uri.Scheme != "postgresql" {
+		return connPlan{}, &ErrInvalidURI{
+			Msg: "invalid connection scheme " + uri.Scheme,
+		}
+	}
+
+	query, err := url.ParseQuery(uri.RawQuery)
+	if err != nil {
+		return connPlan{}, &ErrInvalidURI{
+			Err: err,
+		}
+	}
+
+	cp.URIString = uri.String()
+	cp.SSLMode, cp.SSLKey, cp.SSLCert, cp.SSLRootCert = SSLMode(sslMode), sslKey, sslCert, sslRoot
+
+	if sslmode := query.Get("sslmode"); sslmode != "" {
+		cp.SSLMode = SSLMode(sslmode)
+	}
+
+	return cp, nil
+}
+
+// sourceName identifies the origin of value used
+// during the resolution of configuration values.
+type sourceName string
+
+const (
+	sourceEnv     sourceName = "env"
+	sourceConfig  sourceName = "config"
+	sourceDefault sourceName = "default"
+)
+
+// valueSource describes the source of avalue when resolving
+// configuration inputs. The first non-empty source is selected
+// in order.
+type valueSource struct {
+	name  sourceName
+	key   string
+	value string
+}
+
+// runtimeParamRule describes how to resolve a pg runtime parameter where
+// sources the order of what source takes precendence over another.
+//
+// Optionally allows (in order) to:
+//
+//	a) transform the value via callback
+//	b) omit the value if callback is true
+type runtimeParamRule struct {
+	Name      string
+	Sources   []valueSource
+	Transform func(string) string // optional: transform value e.g. uppercase
+	OmitIf    func(string) bool   // optional: if true, do not set the param
+}
+
+// defaultRuntimeParamSpecs returns the (currently available) runtime param rules
+// for the PostGIS provider.
+//
+// NOTE: @iwpnd - the entire thing seems bloated at first, but makes
+// adding, updating or deleting possible runtime paremters so much easier.
+func defaultRuntimeParamRules() []runtimeParamRule {
+	return []runtimeParamRule{
+		{
+			Name: "application_name",
+			Sources: []valueSource{
+				{
+					name: sourceEnv,
+					key:  "PGAPPNAME",
+				},
+				{
+					name: sourceConfig,
+					key:  ConfigKeyApplicationName,
+				},
+				{
+					name:  sourceDefault,
+					value: DefaultApplicationName,
+				},
+			},
+		},
+		{
+			Name: "default_transaction_read_only",
+			Sources: []valueSource{
+				{
+					name: sourceConfig,
+					key:  ConfigKeyDefaultTransactionReadOnly,
+				},
+				{
+					name:  sourceDefault,
+					value: DefaultDefaultTransactionReadOnly,
+				},
+			},
+			OmitIf: func(v string) bool {
+				return v == "" || v == "OFF"
+			},
+		},
+		{
+			Name: ConfigKeyPoolMinConns,
+			Sources: []valueSource{
+				{
+					name: sourceConfig,
+					key:  ConfigKeyPoolMinConns,
+				},
+			},
+			OmitIf: omitIfEmpty,
+		},
+		{
+			Name: ConfigKeyPoolMinIdleConns,
+			Sources: []valueSource{
+				{
+					name: sourceConfig,
+					key:  ConfigKeyPoolMinIdleConns,
+				},
+			},
+			OmitIf: omitIfEmpty,
+		},
+		{
+			Name: ConfigKeyPoolMaxConnLifeTime,
+			Sources: []valueSource{
+				{
+					name: sourceConfig,
+					key:  ConfigKeyPoolMaxConnLifeTime,
+				},
+			},
+			OmitIf: omitIfEmpty,
+		},
+		{
+			Name: ConfigKeyPoolMaxConnIdleTime,
+			Sources: []valueSource{
+				{
+					name: sourceConfig,
+					key:  ConfigKeyPoolMaxConnIdleTime,
+				},
+			},
+			OmitIf: omitIfEmpty,
+		},
+		{
+			Name: ConfigKeyPoolHealthCheckPeriod,
+			Sources: []valueSource{
+				{
+					name: sourceConfig,
+					key:  ConfigKeyPoolHealthCheckPeriod,
+				},
+			},
+			OmitIf: omitIfEmpty,
+		},
+		{
+			Name: ConfigKeyPoolMaxConnLifeTimeJitter,
+			Sources: []valueSource{
+				{
+					name: sourceConfig,
+					key:  ConfigKeyPoolMaxConnLifeTimeJitter,
+				},
+			},
+			OmitIf: omitIfEmpty,
+		},
+	}
+}
+
+func omitIfEmpty(v string) bool { return v == "" }
+
+// resolveRunTimeParams resolves runtime parameters according to the
+// provided rules. For each rule, sources are evaluated in order and
+// the first non-empty value is selected, optionally transformed, and
+// conditionally omitted.
+func resolveRunTimeParams(cfg dict.Dicter, rules []runtimeParamRule) map[string]string {
+	out := map[string]string{}
+
+	for _, rule := range rules {
+		value := ""
+
+		for _, src := range rule.Sources {
+			candidate := ""
+
+			switch src.name {
+			case sourceEnv:
+				candidate = os.Getenv(src.key)
+			case sourceConfig:
+				candidate, _ = cfg.String(src.key, nil) //nolint:errcheck
+			default:
+				candidate = src.value
+			}
+
+			if candidate != "" {
+				value = candidate
+				break
+			}
+		}
+
+		if rule.Transform != nil {
+			value = rule.Transform(value)
+		}
+
+		if rule.OmitIf != nil && rule.OmitIf(value) {
+			continue
+		}
+
+		if value != "" {
+			out[rule.Name] = value
+		}
+	}
+
+	return out
+}

--- a/provider/postgis/planner_test.go
+++ b/provider/postgis/planner_test.go
@@ -1,0 +1,264 @@
+package postgis
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/go-spatial/tegola/dict"
+)
+
+func TestConnPlanerConnModeEnv(t *testing.T) {
+	type tcase struct {
+		mode           connMode
+		config         dict.Dicter
+		envTriggerKeys []string
+		setupFn        func(t *testing.T, triggers []string)
+		expectedPlan   connPlan
+
+		expectErrFn func(t *testing.T, err error)
+	}
+
+	fn := func(t *testing.T, tc tcase) {
+		planer := defaultPlanner{}
+
+		plan, err := planer.Plan(tc.config, tc.mode, tc.envTriggerKeys)
+		if err != nil && tc.expectErrFn == nil {
+			t.Fatalf("expected plan to succeed but got: %s", err)
+		}
+		if err != nil && tc.expectErrFn != nil {
+			tc.expectErrFn(t, err)
+			return
+		}
+
+		if !reflect.DeepEqual(tc.expectedPlan, plan) {
+			t.Fatalf("plans differ\nexpected: %#v\nactual:   %#v", tc.expectedPlan, plan)
+		}
+	}
+
+	tcases := map[string]tcase{
+		"all env overwrites": {
+			mode:           connModeEnv,
+			config:         dict.Dict{},
+			envTriggerKeys: append(connModeEnvTriggers, sslEnvVars...),
+			setupFn: func(t *testing.T, triggers []string) {
+				for _, trigger := range triggers {
+					t.Setenv(trigger, "test")
+				}
+			},
+			expectedPlan: connPlan{
+				Mode:           connModeEnv,
+				EnvTriggerKeys: append(connModeEnvTriggers, sslEnvVars...),
+				URIProvided:    false,
+				URIString:      "",
+
+				SSLMode:     "test",
+				SSLKey:      "test",
+				SSLCert:     "test",
+				SSLRootCert: "test",
+
+				RuntimeParams: resolveRunTimeParams(dict.Dict{}, defaultRuntimeParamRules()),
+			},
+		},
+		"connection env overwrites, ssl defaults": {
+			mode:           connModeEnv,
+			config:         dict.Dict{},
+			envTriggerKeys: connModeEnvTriggers,
+			setupFn: func(t *testing.T, triggers []string) {
+				for _, trigger := range triggers {
+					t.Setenv(trigger, "test")
+				}
+				// CI uses PGSSLMode disable so we overwrite here
+				t.Setenv("PGSSLMODE", "prefer")
+			},
+			expectedPlan: connPlan{
+				Mode:           connModeEnv,
+				EnvTriggerKeys: connModeEnvTriggers,
+				URIProvided:    false,
+				URIString:      "",
+
+				SSLMode:     DefaultSSLMode,
+				SSLKey:      DefaultSSLKey,
+				SSLCert:     DefaultSSLCert,
+				SSLRootCert: "",
+
+				RuntimeParams: resolveRunTimeParams(dict.Dict{}, defaultRuntimeParamRules()),
+			},
+		},
+		"ssl overwrites": {
+			mode:           connModeEnv,
+			config:         dict.Dict{},
+			envTriggerKeys: sslEnvVars,
+			setupFn: func(t *testing.T, triggers []string) {
+				for _, trigger := range triggers {
+					t.Setenv(trigger, "test")
+				}
+			},
+			expectedPlan: connPlan{
+				Mode:           connModeEnv,
+				EnvTriggerKeys: sslEnvVars,
+				URIProvided:    false,
+				URIString:      "",
+
+				SSLMode:     "test",
+				SSLKey:      "test",
+				SSLCert:     "test",
+				SSLRootCert: "test",
+
+				RuntimeParams: resolveRunTimeParams(dict.Dict{}, defaultRuntimeParamRules()),
+			},
+		},
+		"no env overwrites and uri provided": {
+			mode:           connModeURI,
+			config:         dict.Dict(map[string]any{"uri": "postgres://user:password@host:1337/dbname"}),
+			envTriggerKeys: connModeEnvTriggers,
+			expectedPlan: connPlan{
+				Mode:           connModeURI,
+				EnvTriggerKeys: connModeEnvTriggers,
+
+				URIProvided: true,
+				URIString:   "postgres://user:password@host:1337/dbname",
+
+				SSLMode:     DefaultSSLMode,
+				SSLKey:      DefaultSSLKey,
+				SSLCert:     DefaultSSLCert,
+				SSLRootCert: "",
+
+				RuntimeParams: resolveRunTimeParams(dict.Dict{}, defaultRuntimeParamRules()),
+			},
+		},
+		"no env overwrites and uri provided and runtime params from config": {
+			mode: connModeURI,
+			config: dict.Dict(map[string]any{
+				"uri":                           "postgres://user:password@host:1337/dbname",
+				"application_name":              "ratatata",
+				"default_transaction_read_only": "true",
+			}),
+			envTriggerKeys: connModeEnvTriggers,
+			expectedPlan: connPlan{
+				Mode:           connModeURI,
+				EnvTriggerKeys: connModeEnvTriggers,
+
+				URIProvided: true,
+				URIString:   "postgres://user:password@host:1337/dbname",
+
+				SSLMode:     DefaultSSLMode,
+				SSLKey:      DefaultSSLKey,
+				SSLCert:     DefaultSSLCert,
+				SSLRootCert: "",
+
+				RuntimeParams: map[string]string{
+					"application_name":              "ratatata",
+					"default_transaction_read_only": "true",
+				},
+			},
+		},
+		"no env overwrites and uri provided and runtime params from config with omission": {
+			mode: connModeURI,
+			config: dict.Dict(map[string]any{
+				"uri":                           "postgres://user:password@host:1337/dbname",
+				"application_name":              "ratatata",
+				"default_transaction_read_only": "OFF",
+				"pool_min_conns":                "1",
+			}),
+			envTriggerKeys: connModeEnvTriggers,
+			expectedPlan: connPlan{
+				Mode:           connModeURI,
+				EnvTriggerKeys: connModeEnvTriggers,
+
+				URIProvided: true,
+				URIString:   "postgres://user:password@host:1337/dbname",
+
+				SSLMode:     DefaultSSLMode,
+				SSLKey:      DefaultSSLKey,
+				SSLCert:     DefaultSSLCert,
+				SSLRootCert: "",
+
+				RuntimeParams: map[string]string{
+					"application_name": "ratatata",
+					"pool_min_conns":   "1",
+				},
+			},
+		},
+		"no env overwrites and uri provided and ssl mode overwrite from query": {
+			mode: connModeURI,
+			config: dict.Dict(map[string]any{
+				"uri": "postgres://user:password@host:1337/dbname?sslmode=disable",
+			}),
+			envTriggerKeys: connModeEnvTriggers,
+			expectedPlan: connPlan{
+				Mode:           connModeURI,
+				EnvTriggerKeys: connModeEnvTriggers,
+
+				URIProvided: true,
+				URIString:   "postgres://user:password@host:1337/dbname?sslmode=disable",
+
+				SSLMode:     SSLModeDisable,
+				SSLKey:      DefaultSSLKey,
+				SSLCert:     DefaultSSLCert,
+				SSLRootCert: "",
+
+				RuntimeParams: resolveRunTimeParams(dict.Dict{}, defaultRuntimeParamRules()),
+			},
+		},
+		"not env mode no uri errs": {
+			mode:           connModeURI,
+			config:         dict.Dict(map[string]any{}),
+			envTriggerKeys: []string{},
+			expectErrFn: func(t *testing.T, err error) {
+				t.Helper()
+
+				if err.Error() != "neither env vars nor uri provided" {
+					t.Fatalf("expected empty uri error, got %T (%v)", err, err)
+				}
+			},
+		},
+		"invalid uri scheme": {
+			mode:           connModeURI,
+			config:         dict.Dict(map[string]any{"uri": "https://postgres:postgres@localhost:5432/tegola"}),
+			envTriggerKeys: []string{},
+			expectErrFn: func(t *testing.T, err error) {
+				var e *ErrInvalidURI
+				if !errors.As(err, &e) {
+					t.Fatalf("expected invalid uri error, got %T (%v)", err, err)
+				}
+			},
+		},
+		"invalid character in uri": {
+			mode: connModeURI,
+			config: dict.Dict(map[string]any{
+				"uri": "postgresql://postgres:post<gres@localhost:5432/tegola",
+			}),
+			envTriggerKeys: []string{},
+			expectErrFn: func(t *testing.T, err error) {
+				var e *ErrInvalidURI
+				if !errors.As(err, &e) {
+					t.Fatalf("expected invalid uri error, got %T (%v)", err, err)
+				}
+			},
+		},
+		"invalid character in query params": {
+			mode: connModeURI,
+			config: dict.Dict(map[string]any{
+				"uri": "postgresql://postgres:postgres@localhost:5432/tegola?foo=;bar",
+			}),
+			envTriggerKeys: []string{},
+			expectErrFn: func(t *testing.T, err error) {
+				var e *ErrInvalidURI
+				if !errors.As(err, &e) {
+					t.Fatalf("expected invalid uri error, got %T (%v)", err, err)
+				}
+			},
+		},
+	}
+
+	for name, tc := range tcases {
+		t.Run(name, func(t *testing.T) {
+			if tc.setupFn != nil {
+				tc.setupFn(t, tc.envTriggerKeys)
+			}
+
+			fn(t, tc)
+		})
+	}
+}

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -2,13 +2,7 @@ package postgis
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"errors"
 	"fmt"
-	"net"
-	"net/url"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -22,93 +16,66 @@ import (
 	"github.com/go-spatial/tegola/internal/log"
 	"github.com/go-spatial/tegola/observability"
 	"github.com/go-spatial/tegola/provider"
-	pgxuuid "github.com/jackc/pgx-gofrs-uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/jackc/pgx/v5/tracelog"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 const Name = "postgis"
 
-type connectionPoolCollector struct {
-	*pgxpool.Pool
+const (
+	// We quote the field and table names to prevent colliding with postgres keywords.
+	stdSQL = `SELECT %[1]v FROM %[2]v WHERE "%[3]v" && ` + conf.BboxToken
+	mvtSQL = `SELECT %[1]v FROM %[2]v`
 
-	// providerName the pool is created for
-	// required to make metrics unique
-	providerName string
+	// SQL to get the column names, without hitting the information_schema.
+	// Though it might be better to hit the information_schema.
+	fldsSQL = `SELECT * FROM %[1]v LIMIT 0;`
+)
 
-	maxConnectionDesc        *prometheus.Desc
-	currentConnectionsDesc   *prometheus.Desc
-	availableConnectionsDesc *prometheus.Desc
-}
+const (
+	DefaultSRID                       = tegola.WebMercator
+	DefaultSSLMode                    = "prefer"
+	DefaultSSLKey                     = ""
+	DefaultSSLCert                    = ""
+	DefaultApplicationName            = "tegola"
+	DefaultDefaultTransactionReadOnly = "TRUE"
+)
 
-func (c connectionPoolCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
-}
+const (
+	ConfigKeyName                       = "name"
+	ConfigKeyURI                        = "uri"
+	ConfigKeySSLMode                    = "ssl_mode"
+	ConfigKeySSLKey                     = "ssl_key"
+	ConfigKeySSLCert                    = "ssl_cert"
+	ConfigKeySSLRootCert                = "ssl_root_cert"
+	ConfigKeySRID                       = "srid"
+	ConfigKeyLayers                     = "layers"
+	ConfigKeyLayerName                  = "name"
+	ConfigKeyTablename                  = "tablename"
+	ConfigKeySQL                        = "sql"
+	ConfigKeyFields                     = "fields"
+	ConfigKeyGeomField                  = "geometry_fieldname"
+	ConfigKeyGeomIDField                = "id_fieldname"
+	ConfigKeyGeomType                   = "geometry_type"
+	ConfigKeyApplicationName            = "application_name"
+	ConfigKeyDefaultTransactionReadOnly = "default_transaction_read_only"
+	ConfigKeyPoolMinConns               = "pool_min_conns"
+	ConfigKeyPoolMinIdleConns           = "pool_min_idle_conns"
+	ConfigKeyPoolMaxConnLifeTime        = "pool_max_conn_lifetime"
+	ConfigKeyPoolMaxConnIdleTime        = "pool_max_conn_idletime"
+	ConfigKeyPoolHealthCheckPeriod      = "pool_health_check_period"
+	ConfigKeyPoolMaxConnLifeTimeJitter  = "pool_max_conn_lifetime_jitter"
+)
 
-func (c connectionPoolCollector) Collect(ch chan<- prometheus.Metric) {
-	if c.Pool == nil {
-		return
-	}
-	stat := c.Stat()
+var (
+	// isSelectQuery is a regexp to check if a query starts with `SELECT`,
+	// case-insensitive and ignoring any preceding whitespace and SQL comments.
+	isSelectQuery = regexp.MustCompile(`(?i)^((\s*)(--.*\n)?)*select`)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.maxConnectionDesc,
-		prometheus.GaugeValue,
-		float64(stat.MaxConns()),
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.currentConnectionsDesc,
-		prometheus.GaugeValue,
-		float64(stat.AcquiredConns()),
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.availableConnectionsDesc,
-		prometheus.GaugeValue,
-		float64(stat.MaxConns()-stat.AcquiredConns()),
-	)
-}
-
-func (c *connectionPoolCollector) Collectors(
-	prefix string,
-	_ func(configKey string) map[string]any,
-) ([]observability.Collector, error) {
-	if c == nil {
-		return nil, nil
-	}
-	if prefix != "" && !strings.HasSuffix(prefix, "_") {
-		prefix = prefix + "_"
-	}
-
-	// a constant label ensures that the metrics are unique
-	// this allows the registration of multiple providers in the same
-	// config.
-	c.maxConnectionDesc = prometheus.NewDesc(
-		prefix+"postgres_max_connections",
-		"Max number of postgres connections in the pool",
-		nil,
-		prometheus.Labels{"provider_name": c.providerName},
-	)
-
-	c.currentConnectionsDesc = prometheus.NewDesc(
-		prefix+"postgres_current_connections",
-		"Current number of postgres connections in the pool",
-		nil,
-		prometheus.Labels{"provider_name": c.providerName},
-	)
-
-	c.availableConnectionsDesc = prometheus.NewDesc(
-		prefix+"postgres_available_connections",
-		"Current number of available postgres connections in the pool",
-		nil,
-		prometheus.Labels{"provider_name": c.providerName},
-	)
-
-	return []observability.Collector{c}, nil
-}
+	// reference to all instantiated providers
+	providers []Provider
+)
 
 // Provider provides the postgis data provider.
 type Provider struct {
@@ -172,711 +139,6 @@ func (p *Provider) Collectors(
 
 	p.collectorsRegistered = true
 	return append(c, p.mvtProviderQueryHistogramSeconds, p.queryHistogramSeconds), nil
-}
-
-const (
-	// We quote the field and table names to prevent colliding with postgres keywords.
-	stdSQL = `SELECT %[1]v FROM %[2]v WHERE "%[3]v" && ` + conf.BboxToken
-	mvtSQL = `SELECT %[1]v FROM %[2]v`
-
-	// SQL to get the column names, without hitting the information_schema.
-	// Though it might be better to hit the information_schema.
-	fldsSQL = `SELECT * FROM %[1]v LIMIT 0;`
-)
-
-const (
-	DefaultSRID                       = tegola.WebMercator
-	DefaultSSLMode                    = "prefer"
-	DefaultSSLKey                     = ""
-	DefaultSSLCert                    = ""
-	DefaultApplicationName            = "tegola"
-	DefaultDefaultTransactionReadOnly = "TRUE"
-)
-
-const (
-	ConfigKeyName                       = "name"
-	ConfigKeyURI                        = "uri"
-	ConfigKeySSLMode                    = "ssl_mode"
-	ConfigKeySSLKey                     = "ssl_key"
-	ConfigKeySSLCert                    = "ssl_cert"
-	ConfigKeySSLRootCert                = "ssl_root_cert"
-	ConfigKeySRID                       = "srid"
-	ConfigKeyLayers                     = "layers"
-	ConfigKeyLayerName                  = "name"
-	ConfigKeyTablename                  = "tablename"
-	ConfigKeySQL                        = "sql"
-	ConfigKeyFields                     = "fields"
-	ConfigKeyGeomField                  = "geometry_fieldname"
-	ConfigKeyGeomIDField                = "id_fieldname"
-	ConfigKeyGeomType                   = "geometry_type"
-	ConfigKeyApplicationName            = "application_name"
-	ConfigKeyDefaultTransactionReadOnly = "default_transaction_read_only"
-)
-
-// isSelectQuery is a regexp to check if a query starts with `SELECT`,
-// case-insensitive and ignoring any preceding whitespace and SQL comments.
-var isSelectQuery = regexp.MustCompile(`(?i)^((\s*)(--.*\n)?)*select`)
-
-// validateURI validates for minimum requirements for a valid postgresql uri.
-func validateURI(u string) error {
-	uri, err := url.Parse(u)
-	if err != nil {
-		return ErrInvalidURI{Err: err}
-	}
-
-	if uri.Scheme != "postgres" && uri.Scheme != "postgresql" {
-		return ErrInvalidURI{
-			Msg: fmt.Sprintf("invalid connection scheme (%v)", uri.Scheme),
-		}
-	}
-
-	if uri.User == nil {
-		return ErrInvalidURI{Msg: "auth credentials missing"}
-	}
-
-	host, port, err := net.SplitHostPort(uri.Host)
-	if err != nil {
-		return ErrInvalidURI{
-			Err: fmt.Errorf("splitting host port error: %w", err),
-		}
-	}
-
-	if host == "" {
-		return ErrInvalidURI{
-			Msg: fmt.Sprintf("address %v:%v: missing host in address", host, port),
-		}
-	}
-
-	if uri.Path == "" {
-		return ErrInvalidURI{Msg: "missing database"}
-	}
-
-	return nil
-}
-
-// BuildURI creates a database URI from config.
-func BuildURI(config dict.Dicter) (*url.URL, *url.Values, error) {
-	sslmode := DefaultSSLMode
-	sslmode, err := config.String(ConfigKeySSLMode, &sslmode)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	uri, err := config.String(ConfigKeyURI, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := validateURI(uri); err != nil {
-		return nil, nil, err
-	}
-
-	parsedUri, err := url.Parse(uri)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// parse query to make sure sslmode is attached
-	parsedQuery, err := url.ParseQuery(parsedUri.RawQuery)
-	if err != nil {
-		return &url.URL{}, nil, err
-	}
-
-	if ok := parsedQuery.Get("sslmode"); ok == "" {
-		parsedQuery.Add("sslmode", sslmode)
-	}
-
-	parsedUri.RawQuery = parsedQuery.Encode()
-
-	return parsedUri, &parsedQuery, nil
-}
-
-type DBConfigOptions struct {
-	Uri                        string
-	DefaultTransactionReadOnly string
-	ApplicationName            string
-}
-
-func (opts *DBConfigOptions) GetRuntimeParams() map[string]string {
-	pr := map[string]string{
-		ConfigKeyApplicationName: opts.ApplicationName,
-	}
-
-	// as per https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-READ-ONLY
-	// default_transaction_read_only accepts boolean, and is not set by default
-	// hence if OFF, we do not add it to RuntimeParams
-	if opts.DefaultTransactionReadOnly != "" &&
-		strings.ToUpper(opts.DefaultTransactionReadOnly) != "OFF" {
-		pr[ConfigKeyDefaultTransactionReadOnly] = strings.ToUpper(opts.DefaultTransactionReadOnly)
-	}
-
-	return pr
-}
-
-// BuildDBConfig build db config with defaults
-func BuildDBConfig(opts *DBConfigOptions) (*pgxpool.Config, error) {
-	dbconfig, err := pgxpool.ParseConfig(opts.Uri)
-	if err != nil {
-		return nil, err
-	}
-
-	dbconfig.ConnConfig.RuntimeParams = opts.GetRuntimeParams()
-
-	// NOTE: reflects previous pgx/v4 behaviour of passing pgx.loglevelwarn
-	logAdapter := NewLoggerAdapter()
-	tracer := &tracelog.TraceLog{
-		Logger:   logAdapter,
-		LogLevel: tracelog.LogLevelWarn,
-	}
-	dbconfig.ConnConfig.Tracer = tracer
-
-	type hstoreOID struct {
-		OID     uint32
-		hasInit bool
-	}
-	var hstore hstoreOID
-
-	dbconfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
-		// The AfterConnect call runs everytime a new connection is acquired,
-		// including everytime the connection pool expands. The hstore OID
-		// is not constant, so we lookup the OID once per provider and store it.
-		// Extensions have to be registered for every new connection.
-		if !hstore.hasInit {
-			row := conn.QueryRow(ctx, "SELECT oid FROM pg_type WHERE typname = 'hstore';")
-			if err = row.Scan(&hstore.OID); err != nil {
-				switch {
-				case errors.Is(err, pgx.ErrNoRows):
-					// do nothing, because query can be empty if hstore is not installed
-					break
-				default:
-					return fmt.Errorf("error fetching hstore oid: %w", err)
-				}
-			}
-
-			hstore.hasInit = true
-		}
-
-		// dont register hstore data type if hstore extension is not installed
-		if hstore.OID != 0 {
-			conn.TypeMap().RegisterType(&pgtype.Type{
-				Name:  "hstore",
-				OID:   hstore.OID,
-				Codec: pgtype.HstoreCodec{},
-			})
-		}
-
-		// register UUID type, see https://github.com/jackc/pgx/wiki/UUID-Support
-		pgxuuid.Register(conn.TypeMap())
-
-		return nil
-	}
-
-	return dbconfig, nil
-}
-
-// CreateProvider instantiates and returns a new postgis provider or an error.
-// The function will validate that the config object looks good before
-// trying to create a driver. This Provider supports the following fields
-// in the provided map[string]any{} map:
-//
-//	 name (string): [Required] name of the provider
-//		host (string): [Required] postgis database host
-//		port (int): [Required] postgis database port (required)
-//		database (string): [Required] postgis database name
-//		user (string): [Required] postgis database user
-//		password (string): [Required] postgis database password
-//		srid (int): [Optional] The default SRID for the provider. Defaults to WebMercator (3857) but also supports WGS84 (4326)
-//		max_connections : [Optional] The max connections to maintain in the connection pool. Default is 100. 0 means no max.
-//		layers (map[string]struct{})  — This is map of layers keyed by the layer name. supports the following properties
-//
-//			name (string): [Required] the name of the layer. This is used to reference this layer from map layers.
-//			tablename (string): [*Required] the name of the database table to query against. Required if sql is not defined.
-//			geometry_fieldname (string): [Optional] the name of the filed which contains the geometry for the feature. defaults to geom
-//			id_fieldname (string): [Optional] the name of the feature id field. defaults to gid
-//			fields ([]string): [Optional] a list of fields to include alongside the feature. Can be used if sql is not defined.
-//			srid (int): [Optional] the SRID of the layer. Supports 3857 (WebMercator) or 4326 (WGS84).
-//			sql (string): [*Required] custom SQL to use use. Required if tablename is not defined. Supports the following tokens:
-func CreateProvider(
-	config dict.Dicter,
-	maps []provider.Map,
-	providerType string,
-) (*Provider, error) {
-	uri, params, err := BuildURI(config)
-	if err != nil {
-		return nil, err
-	}
-
-	sslmode := params.Get("sslmode")
-
-	sslkey := DefaultSSLKey
-	sslkey, err = config.String(ConfigKeySSLKey, &sslkey)
-	if err != nil {
-		return nil, err
-	}
-
-	sslcert := DefaultSSLCert
-	sslcert, err = config.String(ConfigKeySSLCert, &sslcert)
-	if err != nil {
-		return nil, err
-	}
-
-	sslrootcert := DefaultSSLCert
-	sslrootcert, err = config.String(ConfigKeySSLRootCert, &sslrootcert)
-	if err != nil {
-		return nil, err
-	}
-
-	default_transaction_read_only := DefaultDefaultTransactionReadOnly
-	default_transaction_read_only, err = config.String(
-		ConfigKeyDefaultTransactionReadOnly,
-		&default_transaction_read_only,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	application_name := DefaultApplicationName
-	application_name, err = config.String(ConfigKeyApplicationName, &application_name)
-	if err != nil {
-		return nil, err
-	}
-
-	dbconfig, err := BuildDBConfig(
-		&DBConfigOptions{
-			Uri:                        uri.String(),
-			DefaultTransactionReadOnly: default_transaction_read_only,
-			ApplicationName:            application_name,
-		})
-	if err != nil {
-		return nil, fmt.Errorf("failed while building db config: %w", err)
-	}
-
-	srid := DefaultSRID
-	if srid, err = config.Int(ConfigKeySRID, &srid); err != nil {
-		return nil, err
-	}
-
-	name, err := config.String(ConfigKeyName, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = ConfigTLS(sslmode, sslkey, sslcert, sslrootcert, dbconfig); err != nil {
-		return nil, err
-	}
-
-	p := Provider{
-		srid:   uint64(srid),
-		config: *dbconfig,
-		name:   name,
-	}
-
-	pool, err := pgxpool.NewWithConfig(context.Background(), &p.config)
-	if err != nil {
-		return nil, fmt.Errorf("failed while creating connection pool: %w", err)
-	}
-	p.pool = &connectionPoolCollector{Pool: pool, providerName: name}
-
-	layers, err := config.MapSlice(ConfigKeyLayers)
-	if err != nil {
-		return nil, err
-	}
-
-	lyrs := make(map[string]Layer)
-	lyrsSeen := make(map[string]int)
-
-	for i, layer := range layers {
-		lName, err := layer.String(ConfigKeyLayerName, nil)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"for layer (%v) we got the following error trying to get the layer's name field: %w",
-				i,
-				err,
-			)
-		}
-
-		if j, ok := lyrsSeen[lName]; ok {
-			return nil, fmt.Errorf(
-				"%v layer name is duplicated in both layer %v and layer %v",
-				lName,
-				i,
-				j,
-			)
-		}
-
-		lyrsSeen[lName] = i
-
-		if i == 0 {
-			p.firstLayer = lName
-		}
-
-		fields, err := layer.StringSlice(ConfigKeyFields)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"for layer (%v) %v %v field had the following error: %w",
-				i,
-				lName,
-				ConfigKeyFields,
-				err,
-			)
-		}
-
-		geomfld := "geom"
-		geomfld, err = layer.String(ConfigKeyGeomField, &geomfld)
-		if err != nil {
-			return nil, fmt.Errorf("for layer (%v) %v : %w", i, lName, err)
-		}
-
-		idfld := ""
-		idfld, err = layer.String(ConfigKeyGeomIDField, &idfld)
-		if err != nil {
-			return nil, fmt.Errorf("for layer (%v) %v : %w", i, lName, err)
-		}
-		if idfld == geomfld {
-			return nil, fmt.Errorf(
-				"for layer (%v) %v: %v (%v) and %v field (%v) is the same",
-				i,
-				lName,
-				ConfigKeyGeomField,
-				geomfld,
-				ConfigKeyGeomIDField,
-				idfld,
-			)
-		}
-
-		geomType := ""
-		geomType, err = layer.String(ConfigKeyGeomType, &geomType)
-		if err != nil {
-			return nil, fmt.Errorf("for layer (%v) %v : %w", i, lName, err)
-		}
-
-		var tblName string
-		tblName, err = layer.String(ConfigKeyTablename, &lName)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"for %v layer (%v) %v has an error: %w",
-				i,
-				lName,
-				ConfigKeyTablename,
-				err,
-			)
-		}
-
-		var sql string
-		sql, err = layer.String(ConfigKeySQL, &sql)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"for %v layer (%v) %v has an error: %w",
-				i,
-				lName,
-				ConfigKeySQL,
-				err,
-			)
-		}
-
-		if tblName != lName && sql != "" {
-			log.Debugf(
-				"both %v and %v field are specified for layer (%v) %v, using only %[2]v field.",
-				ConfigKeyTablename,
-				ConfigKeySQL,
-				i,
-				lName,
-			)
-		}
-
-		lsrid := srid
-		if lsrid, err = layer.Int(ConfigKeySRID, &lsrid); err != nil {
-			return nil, err
-		}
-
-		l := Layer{
-			name:      lName,
-			idField:   idfld,
-			geomField: geomfld,
-			srid:      uint64(lsrid),
-		}
-
-		if sql != "" && !isSelectQuery.MatchString(sql) {
-			// if it is not a SELECT query, then we assume we have a sub-query
-			// (`(select ...) as foo`) which we can handle like a tablename
-			tblName = sql
-			sql = ""
-		}
-
-		if sql != "" {
-			// convert !BOX! (MapServer) and !bbox! (Mapnik) to !BBOX! for compatibility
-			sql := strings.Replace(
-				strings.Replace(sql, "!BOX!", conf.BboxToken, -1),
-				"!bbox!",
-				conf.BboxToken,
-				-1,
-			)
-			// make sure that the sql has a !BBOX! token
-			if !strings.Contains(sql, conf.BboxToken) {
-				return nil, fmt.Errorf(
-					"SQL for layer (%v) %v is missing required token: %v",
-					i,
-					lName,
-					conf.BboxToken,
-				)
-			}
-			if !strings.Contains(sql, "*") {
-				if !strings.Contains(sql, geomfld) {
-					return nil, fmt.Errorf(
-						"SQL for layer (%v) %v does not contain the geometry field: %v",
-						i,
-						lName,
-						geomfld,
-					)
-				}
-				if !strings.Contains(sql, idfld) {
-					return nil, fmt.Errorf(
-						"SQL for layer (%v) %v does not contain the id field for the geometry: %v",
-						i,
-						lName,
-						sql,
-					)
-				}
-			}
-
-			// check all tokens are valid
-			for _, token := range provider.ParameterTokenRegexp.FindAllString(sql, -1) {
-				if _, ok := conf.ReservedTokens[token]; !ok {
-					return nil, fmt.Errorf(
-						"SQL for layer (%v) %v references an unknown token %s: %v",
-						i,
-						lName,
-						token,
-						sql,
-					)
-				}
-			}
-
-			l.sql = sql
-		} else {
-			// Tablename and Fields will be used to build the query.
-			// We need to do some work. We need to check to see Fields contains the geom and gid fields
-			// and if not add them to the list. If Fields list is empty/nil we will use '*' for the field list.
-			l.sql, err = genSQL(&l, p.pool, tblName, fields, true, providerType)
-			if err != nil {
-				return nil, fmt.Errorf("could not generate sql, for layer(%v): %w", lName, err)
-			}
-		}
-
-		if debugLayerSQL {
-			log.Debugf("SQL for Layer(%v):\n%v\n", lName, l.sql)
-		}
-
-		// set the layer geom type
-		if geomType != "" {
-			if err = p.setLayerGeomType(&l, geomType); err != nil {
-				return nil, fmt.Errorf(
-					"error fetching geometry type for layer (%v): %w",
-					l.name,
-					err,
-				)
-			}
-		} else {
-			pname, err := config.String(ConfigKeyName, nil)
-			if err != nil {
-				return nil, err
-			}
-
-			if err = p.inspectLayerGeomType(pname, &l, maps); err != nil {
-				return nil, fmt.Errorf("error fetching geometry type for layer (%v): %w\nif custom parameters are used, remember to set %s for the provider", l.name, err, ConfigKeyGeomType)
-			}
-		}
-
-		lyrs[lName] = l
-	}
-	p.layers = lyrs
-
-	// track the provider so we can clean it up later
-	providers = append(providers, p)
-
-	return &p, nil
-}
-
-// ConfigTLS is derived from github.com/jackc/pgx configTLS (https://github.com/jackc/pgx/blob/master/conn.go)
-func ConfigTLS(
-	sslMode string,
-	sslKey string,
-	sslCert string,
-	sslRootCert string,
-	cc *pgxpool.Config,
-) error {
-	switch sslMode {
-	case "disable":
-		cc.ConnConfig.TLSConfig = nil
-		return nil
-	case "allow":
-		cc.ConnConfig.TLSConfig = &tls.Config{InsecureSkipVerify: true}
-	case "prefer":
-		cc.ConnConfig.TLSConfig = &tls.Config{InsecureSkipVerify: true}
-	case "require":
-		cc.ConnConfig.TLSConfig = &tls.Config{InsecureSkipVerify: true}
-	case "verify-ca", "verify-full":
-		cc.ConnConfig.TLSConfig = &tls.Config{
-			ServerName: cc.ConnConfig.Host,
-		}
-	default:
-		return ErrInvalidSSLMode(sslMode)
-	}
-
-	if sslRootCert != "" {
-		caCertPool := x509.NewCertPool()
-
-		caCert, err := os.ReadFile(sslRootCert)
-		if err != nil {
-			return fmt.Errorf("unable to read CA file (%q): %w", sslRootCert, err)
-		}
-
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return fmt.Errorf("unable to add CA to cert pool")
-		}
-
-		cc.ConnConfig.TLSConfig.RootCAs = caCertPool
-		cc.ConnConfig.TLSConfig.ClientCAs = caCertPool
-	}
-
-	if (sslCert == "") != (sslKey == "") {
-		return fmt.Errorf("both 'sslcert' and 'sslkey' are required")
-	} else if sslCert != "" { // we must have both now
-		cert, err := tls.LoadX509KeyPair(sslCert, sslKey)
-		if err != nil {
-			return fmt.Errorf("unable to read cert: %w", err)
-		}
-
-		cc.ConnConfig.TLSConfig.Certificates = []tls.Certificate{cert}
-	}
-
-	return nil
-}
-
-// setLayerGeomType sets the geomType field on the layer to one of point,
-// linestring, polygon, multipoint, multilinestring, multipolygon or
-// geometrycollection
-func (p Provider) setLayerGeomType(l *Layer, geomType string) error {
-	switch strings.ToLower(geomType) {
-	case "point":
-		l.geomType = geom.Point{}
-	case "linestring":
-		l.geomType = geom.LineString{}
-	case "polygon":
-		l.geomType = geom.Polygon{}
-	case "multipoint":
-		l.geomType = geom.MultiPoint{}
-	case "multilinestring":
-		l.geomType = geom.MultiLineString{}
-	case "multipolygon":
-		l.geomType = geom.MultiPolygon{}
-	case "geometrycollection":
-		l.geomType = geom.Collection{}
-	default:
-		return fmt.Errorf("unsupported geometry_type (%v) for layer (%v)", geomType, l.name)
-	}
-	return nil
-}
-
-// inspectLayerGeomType sets the geomType field on the layer by running the SQL
-// and reading the geom type in the result set
-func (p Provider) inspectLayerGeomType(pname string, l *Layer, maps []provider.Map) error {
-	var err error
-
-	// we want to know the geom type instead of returning the geom data so we modify the SQL
-	// TODO (arolek): this strategy wont work if remove the requirement of wrapping ST_AsBinary(geom) in the SQL statements.
-	//
-	// https://github.com/go-spatial/tegola/issues/180
-	//
-	// case insensitive search
-
-	re := regexp.MustCompile(`(?i)ST_AsBinary`)
-	sql := re.ReplaceAllString(l.sql, "ST_GeometryType")
-
-	re = regexp.MustCompile(`(?i)(ST_AsMVTGeom\(.*\))`)
-	if re.MatchString(sql) {
-		sql = fmt.Sprintf("SELECT ST_GeometryType(%v) FROM (%v) as q", l.geomField, sql)
-	}
-
-	// we only need a single result set to sniff out the geometry type
-	sql = fmt.Sprintf("%v LIMIT 1", sql)
-
-	// if a !ZOOM! token exists, all features could be filtered out so we don't have a geometry to inspect it's type.
-	// address this by replacing the !ZOOM! token with an ANY statement which includes all zooms
-	sql = strings.Replace(
-		sql,
-		"!ZOOM!",
-		"ANY('{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}')",
-		1,
-	)
-
-	// we need a tile to run our sql through the replacer
-	tile := provider.NewTile(0, 0, 0, 64, tegola.WebMercator)
-
-	// normal replacer
-	sql, err = replaceTokens(sql, l, tile, true)
-	if err != nil {
-		return err
-	}
-
-	// substitute default values to parameter
-	params := extractQueryParamValues(pname, maps, l)
-
-	args := make([]any, 0)
-	sql = params.ReplaceParams(sql, &args)
-
-	if provider.ParameterTokenRegexp.MatchString(sql) {
-		// remove all parameter tokens for inspection
-		// crossing our fingers that the query is still valid 🤞
-		// if not, the user will have to specify `geometry_type` in the config
-		sql = provider.ParameterTokenRegexp.ReplaceAllString(sql, "")
-	}
-
-	rows, err := p.pool.Query(context.Background(), sql, args...)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-
-	// fetch rows FieldDescriptions. this gives us the OID for the data types returned to aid in decoding
-	fdescs := rows.FieldDescriptions()
-	for rows.Next() {
-		vals, err := rows.Values()
-		if err != nil {
-			return fmt.Errorf("error running SQL: %v ; %w", sql, err)
-		}
-
-		// iterate the values returned from our row, sniffing for the geomField or st_geometrytype field name
-		for i, v := range vals {
-			switch string(fdescs[i].Name) {
-			case l.geomField, "st_geometrytype":
-				switch v {
-				case "ST_Point":
-					l.geomType = geom.Point{}
-				case "ST_LineString":
-					l.geomType = geom.LineString{}
-				case "ST_Polygon":
-					l.geomType = geom.Polygon{}
-				case "ST_MultiPoint":
-					l.geomType = geom.MultiPoint{}
-				case "ST_MultiLineString":
-					l.geomType = geom.MultiLineString{}
-				case "ST_MultiPolygon":
-					l.geomType = geom.MultiPolygon{}
-				case "ST_GeometryCollection":
-					l.geomType = geom.Collection{}
-				default:
-					return fmt.Errorf(
-						"layer (%v) returned unsupported geometry type (%v)",
-						l.name,
-						v,
-					)
-				}
-			}
-		}
-	}
-
-	return rows.Err()
 }
 
 // Layer fetches an individual layer from the provider, if it's configured
@@ -1176,8 +438,438 @@ func (p Provider) MVTForLayers(
 // Close will close the Provider's database connectio
 func (p *Provider) Close() { p.pool.Close() }
 
-// reference to all instantiated providers
-var providers []Provider
+// setLayerGeomType sets the geomType field on the layer to one of point,
+// linestring, polygon, multipoint, multilinestring, multipolygon or
+// geometrycollection
+func (p Provider) setLayerGeomType(l *Layer, geomType string) error {
+	switch strings.ToLower(geomType) {
+	case "point":
+		l.geomType = geom.Point{}
+	case "linestring":
+		l.geomType = geom.LineString{}
+	case "polygon":
+		l.geomType = geom.Polygon{}
+	case "multipoint":
+		l.geomType = geom.MultiPoint{}
+	case "multilinestring":
+		l.geomType = geom.MultiLineString{}
+	case "multipolygon":
+		l.geomType = geom.MultiPolygon{}
+	case "geometrycollection":
+		l.geomType = geom.Collection{}
+	default:
+		return fmt.Errorf("unsupported geometry_type (%v) for layer (%v)", geomType, l.name)
+	}
+	return nil
+}
+
+// inspectLayerGeomType sets the geomType field on the layer by running the SQL
+// and reading the geom type in the result set
+func (p Provider) inspectLayerGeomType(pname string, l *Layer, maps []provider.Map) error {
+	var err error
+
+	// we want to know the geom type instead of returning the geom data so we modify the SQL
+	// TODO (arolek): this strategy wont work if remove the requirement of wrapping ST_AsBinary(geom) in the SQL statements.
+	//
+	// https://github.com/go-spatial/tegola/issues/180
+	//
+	// case insensitive search
+
+	re := regexp.MustCompile(`(?i)ST_AsBinary`)
+	sql := re.ReplaceAllString(l.sql, "ST_GeometryType")
+
+	re = regexp.MustCompile(`(?i)(ST_AsMVTGeom\(.*\))`)
+	if re.MatchString(sql) {
+		sql = fmt.Sprintf("SELECT ST_GeometryType(%v) FROM (%v) as q", l.geomField, sql)
+	}
+
+	// we only need a single result set to sniff out the geometry type
+	sql = fmt.Sprintf("%v LIMIT 1", sql)
+
+	// if a !ZOOM! token exists, all features could be filtered out so we don't have a geometry to inspect it's type.
+	// address this by replacing the !ZOOM! token with an ANY statement which includes all zooms
+	sql = strings.Replace(
+		sql,
+		"!ZOOM!",
+		"ANY('{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}')",
+		1,
+	)
+
+	// we need a tile to run our sql through the replacer
+	tile := provider.NewTile(0, 0, 0, 64, tegola.WebMercator)
+
+	// normal replacer
+	sql, err = replaceTokens(sql, l, tile, true)
+	if err != nil {
+		return err
+	}
+
+	// substitute default values to parameter
+	params := extractQueryParamValues(pname, maps, l)
+
+	args := make([]any, 0)
+	sql = params.ReplaceParams(sql, &args)
+
+	if provider.ParameterTokenRegexp.MatchString(sql) {
+		// remove all parameter tokens for inspection
+		// crossing our fingers that the query is still valid 🤞
+		// if not, the user will have to specify `geometry_type` in the config
+		sql = provider.ParameterTokenRegexp.ReplaceAllString(sql, "")
+	}
+
+	rows, err := p.pool.Query(context.Background(), sql, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	// fetch rows FieldDescriptions. this gives us the OID for the data types returned to aid in decoding
+	fdescs := rows.FieldDescriptions()
+	for rows.Next() {
+		vals, err := rows.Values()
+		if err != nil {
+			return fmt.Errorf("error running SQL: %v ; %w", sql, err)
+		}
+
+		// iterate the values returned from our row, sniffing for the geomField or st_geometrytype field name
+		for i, v := range vals {
+			switch string(fdescs[i].Name) {
+			case l.geomField, "st_geometrytype":
+				switch v {
+				case "ST_Point":
+					l.geomType = geom.Point{}
+				case "ST_LineString":
+					l.geomType = geom.LineString{}
+				case "ST_Polygon":
+					l.geomType = geom.Polygon{}
+				case "ST_MultiPoint":
+					l.geomType = geom.MultiPoint{}
+				case "ST_MultiLineString":
+					l.geomType = geom.MultiLineString{}
+				case "ST_MultiPolygon":
+					l.geomType = geom.MultiPolygon{}
+				case "ST_GeometryCollection":
+					l.geomType = geom.Collection{}
+				default:
+					return fmt.Errorf(
+						"layer (%v) returned unsupported geometry type (%v)",
+						l.name,
+						v,
+					)
+				}
+			}
+		}
+	}
+
+	return rows.Err()
+}
+
+// CreateProvider instantiates and returns a new PostGIS provider or an error.
+//
+// Connection configuration is resolved using either a PostgreSQL connection
+// URI or environment variables, with environment variables taking precedence.
+//
+// The provider requires:
+//
+//   - name (string): [Required] unique name of the provider.
+//   - uri (string): [Required unless environment mode is used] full PostgreSQL
+//     connection URI (postgres:// or postgresql://).
+//
+// Connection resolution rules:
+//
+//  1. If one or more PostgreSQL environment variables relevant to connection
+//     configuration (e.g. PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD,
+//     PGSSLMODE, etc.) are present, the provider operates in environment mode.
+//     In this mode, connection parameters are derived from the environment
+//     and the configured URI (if provided) is ignored.
+//
+//  2. If no environment trigger variables are present, the configured URI
+//     is used.
+//
+// In environment mode, strict validation is applied to the resolved
+// configuration to ensure host, port, database, and user are set. If the
+// configuration is incomplete, provider initialization fails with a
+// descriptive error.
+//
+// When multiple PostGIS providers are defined within a single Tegola
+// configuration, using explicit URIs is strongly recommended. Environment
+// variables apply process-wide and will override all PostGIS providers
+// uniformly, potentially leading to unintended shared connections.
+//
+// Additional provider configuration:
+//
+//   - srid (int): [Optional] default SRID for the provider. Defaults to
+//     WebMercator (3857) but also supports WGS84 (4326).
+//
+//   - max_connections (int): [Optional] maximum number of connections in the
+//     pool. Default is 100. A value of 0 disables the limit.
+//
+//   - layers (map[string]struct{}): map of layers keyed by layer name. Each
+//     layer supports:
+//
+//   - name (string): [Required] name of the layer.
+//
+//   - tablename (string): [Required if sql is not defined] database table
+//     to query.
+//
+//   - geometry_fieldname (string): [Optional] geometry column name.
+//     Defaults to "geom".
+//
+//   - id_fieldname (string): [Optional] feature ID column.
+//
+//   - fields ([]string): [Optional] additional fields to include if sql
+//     is not defined.
+//
+//   - srid (int): [Optional] layer SRID (3857 or 4326).
+//
+//   - sql (string): [Required if tablename is not defined] custom SQL
+//     statement. The SQL must include required tokens where applicable.
+func CreateProvider(
+	config dict.Dicter,
+	maps []provider.Map,
+	providerType string,
+) (*Provider, error) {
+	c := newDefaultConnector(config)
+	pool, pgxCfg, _, err := c.Connect(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	srid := DefaultSRID
+	if srid, err = config.Int(ConfigKeySRID, &srid); err != nil {
+		return nil, err
+	}
+	name, err := config.String(ConfigKeyName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	p := Provider{
+		srid:   uint64(srid),
+		config: *pgxCfg,
+		name:   name,
+	}
+
+	p.pool = &connectionPoolCollector{Pool: pool, providerName: name}
+
+	layers, err := config.MapSlice(ConfigKeyLayers)
+	if err != nil {
+		return nil, err
+	}
+
+	lyrs := make(map[string]Layer)
+	lyrsSeen := make(map[string]int)
+
+	for i, layer := range layers {
+		lName, err := layer.String(ConfigKeyLayerName, nil)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"for layer (%v) we got the following error trying to get the layer's name field: %w",
+				i,
+				err,
+			)
+		}
+
+		if j, ok := lyrsSeen[lName]; ok {
+			return nil, fmt.Errorf(
+				"%v layer name is duplicated in both layer %v and layer %v",
+				lName,
+				i,
+				j,
+			)
+		}
+
+		lyrsSeen[lName] = i
+
+		if i == 0 {
+			p.firstLayer = lName
+		}
+
+		fields, err := layer.StringSlice(ConfigKeyFields)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"for layer (%v) %v %v field had the following error: %w",
+				i,
+				lName,
+				ConfigKeyFields,
+				err,
+			)
+		}
+
+		geomfld := "geom"
+		geomfld, err = layer.String(ConfigKeyGeomField, &geomfld)
+		if err != nil {
+			return nil, fmt.Errorf("for layer (%v) %v : %w", i, lName, err)
+		}
+
+		idfld := ""
+		idfld, err = layer.String(ConfigKeyGeomIDField, &idfld)
+		if err != nil {
+			return nil, fmt.Errorf("for layer (%v) %v : %w", i, lName, err)
+		}
+		if idfld == geomfld {
+			return nil, fmt.Errorf(
+				"for layer (%v) %v: %v (%v) and %v field (%v) is the same",
+				i,
+				lName,
+				ConfigKeyGeomField,
+				geomfld,
+				ConfigKeyGeomIDField,
+				idfld,
+			)
+		}
+
+		geomType := ""
+		geomType, err = layer.String(ConfigKeyGeomType, &geomType)
+		if err != nil {
+			return nil, fmt.Errorf("for layer (%v) %v : %w", i, lName, err)
+		}
+
+		var tblName string
+		tblName, err = layer.String(ConfigKeyTablename, &lName)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"for %v layer (%v) %v has an error: %w",
+				i,
+				lName,
+				ConfigKeyTablename,
+				err,
+			)
+		}
+
+		var sql string
+		sql, err = layer.String(ConfigKeySQL, &sql)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"for %v layer (%v) %v has an error: %w",
+				i,
+				lName,
+				ConfigKeySQL,
+				err,
+			)
+		}
+
+		if tblName != lName && sql != "" {
+			log.Debugf(
+				"both %v and %v field are specified for layer (%v) %v, using only %[2]v field.",
+				ConfigKeyTablename,
+				ConfigKeySQL,
+				i,
+				lName,
+			)
+		}
+
+		lsrid := srid
+		if lsrid, err = layer.Int(ConfigKeySRID, &lsrid); err != nil {
+			return nil, err
+		}
+
+		l := Layer{
+			name:      lName,
+			idField:   idfld,
+			geomField: geomfld,
+			srid:      uint64(lsrid),
+		}
+
+		if sql != "" && !isSelectQuery.MatchString(sql) {
+			// if it is not a SELECT query, then we assume we have a sub-query
+			// (`(select ...) as foo`) which we can handle like a tablename
+			tblName = sql
+			sql = ""
+		}
+
+		if sql != "" {
+			// convert !BOX! (MapServer) and !bbox! (Mapnik) to !BBOX! for compatibility
+			sql := strings.ReplaceAll(
+				strings.ReplaceAll(sql, "!BOX!", conf.BboxToken),
+				"!bbox!",
+				conf.BboxToken,
+			)
+			// make sure that the sql has a !BBOX! token
+			if !strings.Contains(sql, conf.BboxToken) {
+				return nil, fmt.Errorf(
+					"SQL for layer (%v) %v is missing required token: %v",
+					i,
+					lName,
+					conf.BboxToken,
+				)
+			}
+			if !strings.Contains(sql, "*") {
+				if !strings.Contains(sql, geomfld) {
+					return nil, fmt.Errorf(
+						"SQL for layer (%v) %v does not contain the geometry field: %v",
+						i,
+						lName,
+						geomfld,
+					)
+				}
+				if !strings.Contains(sql, idfld) {
+					return nil, fmt.Errorf(
+						"SQL for layer (%v) %v does not contain the id field for the geometry: %v",
+						i,
+						lName,
+						sql,
+					)
+				}
+			}
+
+			// check all tokens are valid
+			for _, token := range provider.ParameterTokenRegexp.FindAllString(sql, -1) {
+				if _, ok := conf.ReservedTokens[token]; !ok {
+					return nil, fmt.Errorf(
+						"SQL for layer (%v) %v references an unknown token %s: %v",
+						i,
+						lName,
+						token,
+						sql,
+					)
+				}
+			}
+
+			l.sql = sql
+		} else {
+			// Tablename and Fields will be used to build the query.
+			// We need to do some work. We need to check to see Fields contains the geom and gid fields
+			// and if not add them to the list. If Fields list is empty/nil we will use '*' for the field list.
+			l.sql, err = genSQL(&l, p.pool, tblName, fields, true, providerType)
+			if err != nil {
+				return nil, fmt.Errorf("could not generate sql, for layer(%v): %w", lName, err)
+			}
+		}
+
+		if debugLayerSQL {
+			log.Debugf("SQL for Layer(%v):\n%v\n", lName, l.sql)
+		}
+
+		// set the layer geom type
+		if geomType != "" {
+			if err = p.setLayerGeomType(&l, geomType); err != nil {
+				return nil, fmt.Errorf(
+					"error fetching geometry type for layer (%v): %w",
+					l.name,
+					err,
+				)
+			}
+		} else {
+			pname, err := config.String(ConfigKeyName, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			if err = p.inspectLayerGeomType(pname, &l, maps); err != nil {
+				return nil, fmt.Errorf("error fetching geometry type for layer (%v): %w\nif custom parameters are used, remember to set %s for the provider", l.name, err, ConfigKeyGeomType)
+			}
+		}
+
+		lyrs[lName] = l
+	}
+	p.layers = lyrs
+
+	// track the provider so we can clean it up later
+	providers = append(providers, p)
+
+	return &p, nil
+}
 
 // Cleanup will close all database connections and destroy all previously instantiated Provider instances
 func Cleanup() {

--- a/provider/postgis/selector.go
+++ b/provider/postgis/selector.go
@@ -1,0 +1,68 @@
+package postgis
+
+import "os"
+
+// connMode is the stragey used to establish a connection
+// to a PostGIS database.
+type connMode string
+
+const (
+	// connModeEnv indicates that the connection coonfiguration
+	// should be derived from the environment.
+	connModeEnv connMode = "env"
+	// connModeUri indicates that the connection configuration
+	// should be derived from the uri provided in the configuration.
+	connModeURI connMode = "uri"
+)
+
+// connModeEnvTriggers are those env variables that trigger ConnMode to be env.
+// in which case environment variables are the prefered way of connecting
+// to PostGIS.
+//
+// The focus is on environment variables that a connection relevant.
+// See https://www.postgresql.org/docs/10/libpq-envars.html
+// for an exhaustive list.
+var (
+	connModeEnvTriggers = []string{
+		"PGHOST",
+		"PGPORT",
+		"PGDATABASE",
+		"PGUSER",
+		"PGPASSWORD",
+	}
+	sslEnvVars = []string{
+		"PGSSLMODE",
+		"PGSSLCERT",
+		"PGSSLKEY",
+		"PGSSLROOTCERT",
+	}
+)
+
+// selector defines the behavior required to determine
+// which connection mode should be used.
+type selector interface {
+	Select() (connMode, []string)
+}
+
+// envSelector implements selector by inspecting environment variables.
+type envSelector struct{}
+
+// Select determines the connection mode based on the presense of
+// libpq-related environment variables.
+//
+// If any of the variables in envTriggers is non-empty we assume
+// the connModeEnv, otherwise connModeURI where we expect the presence
+// of a config connection URI.
+func (e envSelector) Select() (connMode, []string) {
+	triggers := []string{}
+	for _, env := range connModeEnvTriggers {
+		if value := os.Getenv(env); value != "" {
+			triggers = append(triggers, env)
+		}
+	}
+	if len(triggers) > 0 {
+		return connModeEnv, triggers
+	}
+
+	return connModeURI, triggers
+}

--- a/provider/postgis/selector_test.go
+++ b/provider/postgis/selector_test.go
@@ -1,0 +1,54 @@
+package postgis
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestEnvSelectorConnModeEnv(t *testing.T) {
+	type tcase struct {
+		triggers         []string
+		expectedConnMode connMode
+	}
+
+	tcases := map[string]tcase{
+		"connModeEnv": {
+			triggers:         connModeEnvTriggers,
+			expectedConnMode: connModeEnv,
+		},
+		"connModeURI": {
+			triggers: []string{
+				"PGAPPNAME",
+				"PGCONNECT_TIMEOUT",
+				"PGTARGETSESSIONATTRS",
+			},
+			expectedConnMode: connModeURI,
+		},
+	}
+
+	fn := func(t *testing.T, tc tcase) {
+		for _, env := range tc.triggers {
+			t.Setenv(env, "test")
+		}
+
+		es := &envSelector{}
+
+		connMode, triggers := es.Select()
+		if connMode != tc.expectedConnMode {
+			t.Fatalf("expected ConnMode to be '%s' but got %s", tc.expectedConnMode, connMode)
+		}
+
+		// noop for connModeURI
+		for _, trigger := range triggers {
+			if !slices.Contains(tc.triggers, trigger) {
+				t.Fatalf("expected all env triggers to be present in returned triggers: %s is missing", trigger)
+			}
+		}
+	}
+
+	for name, tc := range tcases {
+		t.Run(name, func(t *testing.T) {
+			fn(t, tc)
+		})
+	}
+}

--- a/provider/postgis/util.go
+++ b/provider/postgis/util.go
@@ -1,6 +1,7 @@
 package postgis
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strconv"
@@ -17,6 +18,26 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/tracelog"
 )
+
+// buildBuffer joins the provided values slice using a comma delimiter.
+func buildBuffer(vals []string) string {
+	if len(vals) == 0 {
+		return "[]"
+	}
+	size := len(vals) - 1 // n-1 times ","
+	for _, v := range vals {
+		size += len(v)
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, size))
+	for i, v := range vals {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(v)
+	}
+	return buf.String()
+}
 
 // isMVT will return true if the provider is MVT based
 func isMVT(providerType string) bool {

--- a/provider/postgis/validator.go
+++ b/provider/postgis/validator.go
@@ -1,0 +1,84 @@
+package postgis
+
+import "github.com/jackc/pgx/v5/pgxpool"
+
+// connMeta contains sanitized, resolved connection metadata.
+// safe to use in logs and error messages.
+type connMeta struct {
+	Mode           connMode
+	EnvTriggerKeys []string
+
+	Host     string
+	Port     uint16
+	Database string
+	User     string
+
+	SSLMode SSLMode
+}
+
+// newConnMeta constructs a connMeta from connPlan and pgxpool configuration.
+func newConnMeta(plan connPlan, cfg *pgxpool.Config) connMeta {
+	return connMeta{
+		Mode:           plan.Mode,
+		EnvTriggerKeys: plan.EnvTriggerKeys,
+		Host:           cfg.ConnConfig.Host,
+		Port:           cfg.ConnConfig.Port,
+		Database:       cfg.ConnConfig.Database,
+		User:           cfg.ConnConfig.User,
+		SSLMode:        plan.SSLMode,
+	}
+}
+
+// validator defines the interfaces responsible for validation a resolved pool
+// configuration.
+type validator interface {
+	Validate(plan connPlan, cfg *pgxpool.Config) (connMeta, error)
+}
+
+// defaultValidator is the default implementation of validator for
+// the PostGIS provider.
+type defaultValidator struct{}
+
+// Validate performs structural validation of the resolved pgxpool configuration.
+// There is no validation when in URI mode. There is strict validation when in ENV mode.
+func (v defaultValidator) Validate(plan connPlan, cfg *pgxpool.Config) (connMeta, error) {
+	meta := newConnMeta(plan, cfg)
+
+	if meta.Mode != connModeEnv {
+		// we do not validate the content of the uri because it is
+		// explicit and self-cointained.
+		// the amount of viable combinations in a uri is too big
+		// to validate too. if it is malformed or incomplete
+		// pgxpool.ParseConfig or the connection will fail for us on
+		// test ping. see issue#1058.
+		return meta, nil
+	}
+
+	// connModeEnv however is implicit because it is triggered by
+	// ambiant variables. it can also override a perfectly valid
+	// uri so we need to make validation strict and a distriptive error
+	// visible for the user on-connect.
+	missing := []string{}
+	if meta.Host == "" {
+		missing = append(missing, "host")
+	}
+	if meta.Port == 0 {
+		missing = append(missing, "port")
+	}
+	if meta.Database == "" {
+		missing = append(missing, "database")
+	}
+	if meta.User == "" {
+		missing = append(missing, "user")
+	}
+
+	if len(missing) > 0 {
+		return connMeta{}, ErrEnvIncomplete{
+			Triggers:      meta.EnvTriggerKeys,
+			MissingFields: missing,
+			URIWasIgnored: plan.URIProvided,
+		}
+	}
+
+	return meta, nil
+}

--- a/provider/postgis/validator_test.go
+++ b/provider/postgis/validator_test.go
@@ -1,0 +1,103 @@
+package postgis
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestConnValidator(t *testing.T) {
+	type tcase struct {
+		plan      connPlan
+		config    *pgxpool.Config
+		expectErr bool
+	}
+
+	fn := func(t *testing.T, tc tcase) {
+		v := &defaultValidator{}
+		meta, err := v.Validate(tc.plan, tc.config)
+		if tc.expectErr {
+			var e ErrEnvIncomplete
+			if !errors.As(err, &e) {
+				t.Fatalf("expected ErrEnvIncomplete, got %T (%v)", err, err)
+			}
+			return
+		}
+
+		expectedDatabase := tc.config.ConnConfig.Database
+		if meta.Database != expectedDatabase {
+			t.Fatalf("expected database to be %s, got %s", expectedDatabase, meta.Database)
+		}
+		expectedHost := tc.config.ConnConfig.Host
+		if meta.Host != expectedHost {
+			t.Fatalf("expected host to be %s, got %s", expectedHost, meta.Host)
+		}
+		expectedUser := tc.config.ConnConfig.User
+		if meta.User != expectedUser {
+			t.Fatalf("expected user to be %s, got %s", expectedUser, meta.User)
+		}
+		expectedPort := tc.config.ConnConfig.Port
+		if meta.Port != expectedPort {
+			t.Fatalf("expected port to be %d, got %d", expectedPort, meta.Port)
+		}
+	}
+
+	tcases := map[string]tcase{
+		"connModeEnv passes": {
+			plan: connPlan{
+				Mode: connModeEnv,
+			},
+			config: &pgxpool.Config{
+				ConnConfig: &pgx.ConnConfig{
+					Config: pgconn.Config{
+						Host:     "host",
+						Port:     1337,
+						User:     "user",
+						Database: "database",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		"connModeEnv errs": {
+			plan: connPlan{
+				Mode: connModeEnv,
+			},
+			config: &pgxpool.Config{
+				ConnConfig: &pgx.ConnConfig{
+					Config: pgconn.Config{
+						Host: "host",
+						Port: 1337,
+						User: "user",
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"connModeConfig passes": {
+			plan: connPlan{
+				Mode: connModeURI,
+			},
+			config: &pgxpool.Config{
+				ConnConfig: &pgx.ConnConfig{
+					Config: pgconn.Config{
+						Host:     "host",
+						Port:     1337,
+						User:     "user",
+						Database: "database",
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for name, tc := range tcases {
+		t.Run(name, func(t *testing.T) {
+			fn(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
This PR refactors the PostGIS connection handling to make configuration precedence explicit. In previous issues people - rightfully so - complained that we're too strict to enforce a `uri` in a specific form when there's dozen perfectly valid parameter combinations that can be valid connection string. We do however now enforce strict validation in `env` mode. To make this refactor easier, I isolate responsibilities into dedicated components, rather than having a huge function doing it all.

### env mode vs uri mode

```
if env trigger variables present:
    mode = env
    ignore uri, but enrich with config values
else:
    mode = uri, either uri controls it all, or we can enrich with config values
```

One caveat - with #915 we support multiple providers of the same type. If there's two postgis providers in the same map, environment variables that trigger env mode would be used in both providers. Those cases need to be explicitly handled via uri - at least for the basic connection values.

### Changes

- replaced host/port/database/user/password config with a single uri field. That was long overdue. 
- introduced explicit connection modes: `env` or `uri`
- environment variables take full precedence over URI when any trigger (PGHOST,PGPASSWORD,PGUSER,PGDATABASE,PGPORT) is present. 
  - closes #1016
- removed URI and environment merging; only one mode is active
- added strict validation in env mode (host, port, database, user required).
- loosend validation in uri mode. we let pgx handle the validation of malformed uris instead.
  - closes #1058 
- introduced `ErrEnvIncomplete` with clear diagnostics
- centralized connection logic behind a connector
- split connection flow into selector, planner, builder, validator, connector. expandable to other providers. 
- added explicit connect-time `Ping` with bounded timeout to validate a connection
- wrapped ping failures with resolved connection metadata to make errors verbose
- moved `pool_*` configuration to provider config, provider config takes precendence over uri query runtime parameter to allow pool configuration in env mode
- removed legacy connection-building functions
- improved testability through component isolation